### PR TITLE
fix batch loss bug in ft

### DIFF
--- a/easyeditor/models/ft/ft_main.py
+++ b/easyeditor/models/ft/ft_main.py
@@ -200,6 +200,7 @@ def execute_ft(
                     loss = -(torch.gather(probs, 1, target_ids) * loss_mask).sum(
                         1
                     ) / loss_mask.sum(1)
+                    loss = loss.mean()
                 elif hparams.objective_optimization == 'target_new':
                     logits = model(**inputs_targets).logits
                     shift_logits = logits[..., :-1, :].contiguous()


### PR DESCRIPTION
When run `test_ZsreDataSet_Edit()` in the file `edit.py`, an error is reported as follows:
```shell
Traceback (most recent call last):
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/edit.py", line 2704, in <module>
    main()
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/edit.py", line 2614, in main
    metrics, edited_model = test_ZsreDataSet_Edit()
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/edit.py", line 106, in test_ZsreDataSet_Edit
    metrics, edited_model, _ = editor.edit_dataset(ds)
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/easyeditor/editors/editor.py", line 435, in edit_dataset
    edited_model, weights_copy = self.apply_algo(
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/easyeditor/models/ft/ft_main.py", line 34, in apply_ft_to_model
    deltas = execute_ft(model, tok, requests, hparams)
  File "/mnt/sdb1/lin/codes/knowledge_edit/tmp/EasyEdit/easyeditor/models/ft/ft_main.py", line 214, in execute_ft
    print(f"Batch loss {loss.item()}")
RuntimeError: a Tensor with 3 elements cannot be converted to Scalar
```
This error is caused by not taking the mean of the loss when `batchsize > 1`.