### PR TITLE
Fix TypeError in BaseEditor.edit by removing duplicate test_generation parameter from kwargs

### DIFF
--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -133,7 +133,8 @@ class BaseEditor:
         `locality_inputs`: dict
             for locality
         """
-        test_generation = kwargs['test_generation'] if 'test_generation' in kwargs.keys() else False
+        test_generation = kwargs.pop('test_generation', False)
+
         if isinstance(prompts, List):
             assert len(prompts) == len(target_new)
         else:


### PR DESCRIPTION
# Fix TypeError in BaseEditor.edit method

## Description
This pull request fixes a TypeError in the BaseEditor.edit method where the test_generation parameter was being passed multiple times to the edit_requests method.

## Changes
Removed the test_generation parameter from kwargs before calling edit_requests in the edit method.

## Impact
This fix ensures that the test_generation parameter is only passed once, preventing the TypeError and allowing the method to function correctly.