### PR TITLE
Error in computation of covariance matrix of PMET

### DIFF
--- a/easyeditor/models/pmet/pmet_main.py
+++ b/easyeditor/models/pmet/pmet_main.py
@@ -336,6 +336,7 @@ def get_cov(
             sample_size=mom2_n_samples,
             precision=mom2_dtype,
             force_recompute=force_recompute,
+            hparams=hparams
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 


### PR DESCRIPTION
When calculating the covariance matrix of PMET, hparams were not passed. This may lead to errors. 
This PR fixes this behavior. 