### PR TITLE
Fix forward hook output compatibility for newer Transformers

### DIFF
--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -128,10 +128,10 @@ class BaseEditor:
             else:
                 raise NotImplementedError
 
-            if self.tok is not None and (isinstance(self.tok, GPT2Tokenizer) or isinstance(self.tok, GPT2TokenizerFast) or isinstance(self.tok, LlamaTokenizer) or isinstance(self.tok, LlamaTokenizerFast) or isinstance(self.tok, PreTrainedTokenizerFast)) and (hparams.alg_name not in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit','CORE']):
+            if self.tok is not None and (isinstance(self.tok, GPT2Tokenizer) or isinstance(self.tok, GPT2TokenizerFast) or isinstance(self.tok, LlamaTokenizer) or isinstance(self.tok, LlamaTokenizerFast) or isinstance(self.tok, PreTrainedTokenizerFast)) and (hparams.alg_name not in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit','CORE', 'SPHERE']):
                 LOG.info('AutoRegressive Model detected, set the padding side of Tokenizer to left...')
                 self.tok.padding_side = 'left'
-            if self.tok is not None and ('mistral' in self.model_name.lower() or 'llama' in self.model_name.lower() or 'qwen' in self.model_name.lower()) and (hparams.alg_name in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit', 'CORE']):
+            if self.tok is not None and ('mistral' in self.model_name.lower() or 'llama' in self.model_name.lower() or 'qwen' in self.model_name.lower()) and (hparams.alg_name in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit', 'CORE', 'SPHERE']):
                 LOG.info('AutoRegressive Model detected, set the padding side of Tokenizer to right...')
                 self.tok.padding_side = 'right'
         else:
@@ -637,5 +637,4 @@ class BaseEditor:
     ):
         metrics = self.apply_algo(datasets, self.hparams)
         return metrics
-
 

--- a/easyeditor/models/SPHERE/compute_z.py
+++ b/easyeditor/models/SPHERE/compute_z.py
@@ -92,27 +92,21 @@ def compute_z(
         nonlocal target_init
 
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                if isinstance(cur_out, tuple):
-                    target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
-                else:
-                    target_init = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                if isinstance(cur_out, tuple):
-                    if len(lookup_idxs)!=len(cur_out[0]):
-                        cur_out[0][idx, i, :] += delta
-                    else:
-                        cur_out[0][i, idx, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    if len(lookup_idxs)!=len(cur_out):
-                        cur_out[idx, i, :] += delta
-                    else:
-                        cur_out[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -150,10 +144,7 @@ def compute_z(
                 kl_distr_init = kl_log_probs.detach().clone()
 
         # Compute loss on rewriting targets
-        if isinstance(tr[hparams.layer_module_tmp.format(loss_layer)].output, tuple):
-            output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]
-        else:
-            output=tr[hparams.layer_module_tmp.format(loss_layer)].output
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]

--- a/easyeditor/models/__init__.py
+++ b/easyeditor/models/__init__.py
@@ -16,6 +16,7 @@ from .qlora import *
 from .lora import *
 from .dpo import *
 from .alphaedit import *
+from .SPHERE import *
 from .deco import *
 from .dola import *
 from .deepedit_api import *

--- a/easyeditor/models/alphaedit/compute_z.py
+++ b/easyeditor/models/alphaedit/compute_z.py
@@ -92,27 +92,21 @@ def compute_z(
         nonlocal target_init
 
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                if isinstance(cur_out, tuple):
-                    target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
-                else:
-                    target_init = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                if isinstance(cur_out, tuple):
-                    if len(lookup_idxs)!=len(cur_out[0]):
-                        cur_out[0][idx, i, :] += delta
-                    else:
-                        cur_out[0][i, idx, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    if len(lookup_idxs)!=len(cur_out):
-                        cur_out[idx, i, :] += delta
-                    else:
-                        cur_out[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -150,10 +144,7 @@ def compute_z(
                 kl_distr_init = kl_log_probs.detach().clone()
 
         # Compute loss on rewriting targets
-        if isinstance(tr[hparams.layer_module_tmp.format(loss_layer)].output, tuple):
-            output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]
-        else:
-            output=tr[hparams.layer_module_tmp.format(loss_layer)].output
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]

--- a/easyeditor/models/core/compute_z.py
+++ b/easyeditor/models/core/compute_z.py
@@ -101,19 +101,22 @@ def compute_z(
         nonlocal target_init
 
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
 
-                if len(lookup_idxs)!=len(cur_out[0]):
-                    cur_out[0][idx, i, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    cur_out[0][i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -165,7 +168,7 @@ def compute_z(
 
         # Compute loss on rewriting targets
 
-        output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
@@ -196,7 +199,7 @@ def compute_z(
             all_layer_outputs = []
             for mon_ly in monitor_layers:
                 layer_name = hparams.layer_module_tmp.format(mon_ly)
-                monitored_out = tr[layer_name].output[0]
+                monitored_out = nethook.get_hidden_state(tr[layer_name].output)
                 all_layer_outputs.append(monitored_out)
             
             all_layer_outputs = torch.stack(all_layer_outputs, dim=0).to(nll_loss.device)

--- a/easyeditor/models/eamet/compute_z.py
+++ b/easyeditor/models/eamet/compute_z.py
@@ -149,9 +149,10 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init, target_constrain, delta
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             if target_init is None:
                 print("Recording initial value of v*")
-                target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
                 print(f"DEBUG INFO:layer_ks_norm:{layer_ks_norm}")
 
                 if hparams.delta_init == "target_init":
@@ -173,7 +174,9 @@ def compute_z(
                     
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                cur_out[0][i, idx, :] += delta
+                hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -215,7 +218,7 @@ def compute_z(
                 kl_distr_init = kl_log_probs.detach().clone()
 
         # Compute loss on rewriting targets
-        full_repr = tr[hparams.layer_module_tmp.format(loss_layer)].output[0][
+        full_repr = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)[
             : len(rewriting_prompts)
         ]
 

--- a/easyeditor/models/emmet/compute_z.py
+++ b/easyeditor/models/emmet/compute_z.py
@@ -91,19 +91,22 @@ def compute_z(
         nonlocal target_init
 
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
 
-                if len(lookup_idxs)!=len(cur_out[0]):
-                    cur_out[0][idx, i, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    cur_out[0][i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -141,7 +144,7 @@ def compute_z(
 
         # Compute loss on rewriting targets
 
-        output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]

--- a/easyeditor/models/kn/knowledge_neurons/knowledge_neurons/knowledge_neurons.py
+++ b/easyeditor/models/kn/knowledge_neurons/knowledge_neurons/knowledge_neurons.py
@@ -905,6 +905,7 @@ class KnowledgeNeurons:
             "argmax_prob": new_argmax_prob,
         }
 
+        @torch.no_grad()
         def unpatch_fn():
             # reverse modified weights
             for idx, (layer_idx, position) in enumerate(neurons):

--- a/easyeditor/models/memit/compute_z.py
+++ b/easyeditor/models/memit/compute_z.py
@@ -90,33 +90,8 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        def _unwrap_output(output):
-            if isinstance(output, torch.Tensor):
-                return output, None
-            if isinstance(output, (list, tuple)):
-                if len(output) == 0:
-                    raise ValueError("Layer output container is empty.")
-                return output[0], output
-            raise TypeError(
-                f"Unsupported layer output type {type(output)} encountered in MEMIT."
-            )
-
-        def _rewrap_output(updated, original):
-            if original is None:
-                return updated
-            if isinstance(original, list):
-                new_out = list(original)
-            elif isinstance(original, tuple):
-                new_out = list(original)
-            else:
-                raise TypeError(
-                    f"Unsupported layer output container {type(original)} in MEMIT."
-                )
-            new_out[0] = updated
-            return type(original)(new_out) if isinstance(original, tuple) else new_out
-
         if cur_layer == hparams.layer_module_tmp.format(layer):
-            layer_output, original_container = _unwrap_output(cur_out)
+            layer_output = nethook.get_hidden_state(cur_out)
 
             # Store initial value of the vector of interest
             if target_init is None:
@@ -132,7 +107,7 @@ def compute_z(
                 else:
                     layer_output[i, idx, :] += delta
 
-            return _rewrap_output(layer_output, original_container)
+            return nethook.replace_hidden_state(cur_out, layer_output)
 
         return cur_out
 
@@ -170,11 +145,7 @@ def compute_z(
 
         # Compute loss on rewriting targets
 
-        loss_layer_out = tr[hparams.layer_module_tmp.format(loss_layer)].output
-        if isinstance(loss_layer_out, (list, tuple)):
-            output = loss_layer_out[0]
-        else:
-            output = loss_layer_out
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
 
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)

--- a/easyeditor/models/pmet/compute_zs.py
+++ b/easyeditor/models/pmet/compute_zs.py
@@ -82,12 +82,14 @@ def compute_zs(
     # Set up an optimization over a latent vector that, when output at the
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
-    if "neo" in model.config._name_or_path or "llama" in model.config._name_or_path:
+    if hasattr(model.config, "n_embd"):
+        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+    elif hasattr(model.config, "hidden_size"):
         delta_attn = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
         delta_mlp = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
     else:
-        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
-        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+        raise NotImplementedError
     target_init_attn, target_init_mlp, kl_distr_init = None, None, None
 
     # Inserts new "delta" variable at the appropriate part of the computation
@@ -95,25 +97,29 @@ def compute_zs(
         nonlocal target_init_attn, target_init_mlp
 
         if cur_layer == hparams.mlp_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init_mlp is None:
                 print("Recording initial value of v* in mlp")
                 # Initial value is recorded for the clean sentence
-                target_init_mlp = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init_mlp = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                cur_out[i, idx, :] += delta_mlp
+                hidden_state[i, idx, :] += delta_mlp
+            return nethook.replace_hidden_state(cur_out, hidden_state)
         if cur_layer == hparams.attn_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init_attn is None:
                 print("Recording initial value of v* in attn")
                 # Initial value is recorded for the clean sentence
-                target_init_attn = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init_attn = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                cur_out[i, idx, :] += delta_attn
+                hidden_state[i, idx, :] += delta_attn
+            return nethook.replace_hidden_state(cur_out, hidden_state)
         return cur_out
 
     # Optimizer
@@ -152,7 +158,7 @@ def compute_zs(
                 kl_distr_init = kl_log_probs.detach().clone()
 
         # Compute loss on rewriting targets
-        full_repr = tr[hparams.layer_module_tmp.format(loss_layer)].output[0][
+        full_repr = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)[
             : len(rewriting_prompts)
         ]
         log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w + lm_b, dim=2)
@@ -286,7 +292,12 @@ def compute_z(
     # Set up an optimization over a latent vector that, when output at the
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
-    delta = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+    if hasattr(model.config, "n_embd"):
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+    elif hasattr(model.config, "hidden_size"):
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
+    else:
+        raise NotImplementedError
     target_init, kl_distr_init = None, None
 
     # Inserts new "delta" variable at the appropriate part of the computation
@@ -294,15 +305,18 @@ def compute_z(
         nonlocal target_init
 
         if cur_layer == hparams.mlp_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                target_init = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                cur_out[i, idx, :] += delta
+                hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -341,7 +355,7 @@ def compute_z(
                 kl_distr_init = kl_log_probs.detach().clone()
 
         # Compute loss on rewriting targets
-        full_repr = tr[hparams.layer_module_tmp.format(loss_layer)].output[0][
+        full_repr = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)[
             : len(rewriting_prompts)
         ]
         log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w + lm_b, dim=2)

--- a/easyeditor/models/r_rome/compute_v.py
+++ b/easyeditor/models/r_rome/compute_v.py
@@ -99,17 +99,20 @@ def compute_v(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
         if cur_layer == hparams.mlp_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                target_init = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             for i, idx in enumerate(lookup_idxs):
-                if len(lookup_idxs) != len(cur_out):
-                    cur_out[idx, i, :] += delta
+                if len(lookup_idxs) != len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    cur_out[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 

--- a/easyeditor/models/rome/compute_v.py
+++ b/easyeditor/models/rome/compute_v.py
@@ -83,17 +83,20 @@ def compute_v(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
         if cur_layer == hparams.mlp_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
                 # Initial value is recorded for the clean sentence
-                target_init = cur_out[0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
                 
             for i, idx in enumerate(lookup_idxs):
-                if len(lookup_idxs)!=len(cur_out):
-                    cur_out[idx, i, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    cur_out[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 

--- a/easyeditor/models/rome/repr_tools.py
+++ b/easyeditor/models/rome/repr_tools.py
@@ -140,12 +140,7 @@ def get_reprs_at_idxs(
 
     def _process(cur_repr, batch_idxs, key):
         nonlocal to_return
-        # Handle tuple outputs - some model hooks return tuples (e.g., transformer blocks)
-        if isinstance(cur_repr, tuple):
-            if len(cur_repr) == 0:
-                # This should not happen with the nethook.py fix, but handle gracefully
-                return
-            cur_repr = cur_repr[0]
+        cur_repr = nethook.get_hidden_state(cur_repr)
         if cur_repr.shape[0]!=len(batch_idxs):
             cur_repr=cur_repr.transpose(0,1)
         for i, idx_list in enumerate(batch_idxs):

--- a/easyeditor/models/unke/compute_z.py
+++ b/easyeditor/models/unke/compute_z.py
@@ -74,18 +74,21 @@ def compute_z(
         nonlocal target_init  
 
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            hidden_state = nethook.get_hidden_state(cur_out)
             
             if target_init is None:
                
-                target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
+                target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
             
             for i, idx in enumerate(lookup_idxs):
                 
-                if len(lookup_idxs)!=len(cur_out[0]):
-                    cur_out[0][idx, i, :] += delta
+                if len(lookup_idxs)!=len(hidden_state):
+                    hidden_state[idx, i, :] += delta
                 else:
-                    cur_out[0][i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, hidden_state)
 
         return cur_out
 
@@ -113,7 +116,7 @@ def compute_z(
 
         # Compute loss on rewriting targets
 
-        output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]  
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)
         full_repr =  output
@@ -162,7 +165,6 @@ def compute_z(
     )
 
     return target
-
 
 
 

--- a/easyeditor/models/unke/unke_main.py
+++ b/easyeditor/models/unke/unke_main.py
@@ -35,7 +35,7 @@ def compute_ks(
                 _ = model(**input_ids)
                 #layer_in_ks = tr.input #(bs:seq:h_dim)
                 zs_out = tr.output#(bs:seq:h_dim)
-    zs_out = zs_out[0] if type(zs_out) is tuple else zs_out
+    zs_out = nethook.get_hidden_state(zs_out)
     zs_out_list=[]
     for i in range(len(zs_out)):
         zs_out_list.append(zs_out[i,idxs[i]])
@@ -117,7 +117,7 @@ def apply_unke_to_model(
                 _ = model(**contexts_tok)
                 layer_in_ks = tr.input #(bs:seq:h_dim)
                 layer_out_ks = tr.output#(bs:seq:h_dim)
-        layer_out_ks = layer_out_ks[0] if type(layer_out_ks) is tuple else layer_out_ks
+        layer_out_ks = nethook.get_hidden_state(layer_out_ks)
         
 
         cur_zs,idxs = compute_ks(model, tok,batch_question, hparams, z_layer)
@@ -142,7 +142,7 @@ def apply_unke_to_model(
                 _ = model(**ex_tok)
                 stat_in = tr.input
                 stat_out = tr.output
-        stat_out = stat_out[0] if type(stat_out) is tuple else stat_out
+        stat_out = nethook.get_hidden_state(stat_out)
 
 
 

--- a/easyeditor/models/unke_ARE/compute_z.py
+++ b/easyeditor/models/unke_ARE/compute_z.py
@@ -104,23 +104,26 @@ def compute_z(
             nonlocal target_init  
 
             if cur_layer == hparams.layer_module_tmp.format(layer):
+                hidden_state = nethook.get_hidden_state(cur_out)
                 
                 if target_init is None:
                 
-                    target_init = cur_out[0][0, lookup_idxs[0]].detach().clone()
+                    target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
                 for idxs_pre, delta_pre in all_delta:
                     for i, idx in enumerate(idxs_pre):
-                        if len(idxs_pre)!=len(cur_out[0]):
-                            cur_out[0][idx, i, :] += delta_pre
+                        if len(idxs_pre)!=len(hidden_state):
+                            hidden_state[idx, i, :] += delta_pre
                         else:
-                            cur_out[0][i, idx, :] += delta_pre
+                            hidden_state[i, idx, :] += delta_pre
                 for i, idx in enumerate(lookup_idxs):
                     
-                    if len(lookup_idxs)!=len(cur_out[0]):
-                        cur_out[0][idx, i, :] += delta
+                    if len(lookup_idxs)!=len(hidden_state):
+                        hidden_state[idx, i, :] += delta
                     else:
-                        cur_out[0][i, idx, :] += delta
+                        hidden_state[i, idx, :] += delta
+
+                return nethook.replace_hidden_state(cur_out, hidden_state)
 
             return cur_out
 
@@ -148,7 +151,7 @@ def compute_z(
 
             # Compute loss on rewriting targets
 
-            output=tr[hparams.layer_module_tmp.format(loss_layer)].output[0]  
+            output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
             if output.shape[1]!=rewriting_targets.shape[1]:
                 output=torch.transpose(output, 0, 1)
             full_repr =  output
@@ -200,7 +203,6 @@ def compute_z(
     )
 
     return all_idxs, all_target
-
 
 
 

--- a/easyeditor/models/unke_ARE/unke_ARE_main.py
+++ b/easyeditor/models/unke_ARE/unke_ARE_main.py
@@ -36,7 +36,7 @@ def compute_ks(
                 _ = model(**input_ids)
                 #layer_in_ks = tr.input #(bs:seq:h_dim)
                 zs_out = tr.output#(bs:seq:h_dim)
-    zs_out = zs_out[0] if type(zs_out) is tuple else zs_out
+    zs_out = nethook.get_hidden_state(zs_out)
     for k, idxs in idxs_dict.items():
         zs_out_list = []
         for idx in idxs:
@@ -119,7 +119,7 @@ def apply_unke_ARE_to_model(
                 _ = model(**contexts_tok)
                 layer_in_ks = tr.input #(bs:seq:h_dim)
                 layer_out_ks = tr.output#(bs:seq:h_dim)
-        layer_out_ks = layer_out_ks[0] if type(layer_out_ks) is tuple else layer_out_ks
+        layer_out_ks = nethook.get_hidden_state(layer_out_ks)
         
 
         cur_zs_dict = compute_ks(model, tok,batch_question_ans, hparams, z_layer, idxs_dict)
@@ -145,7 +145,7 @@ def apply_unke_ARE_to_model(
                 _ = model(**ex_tok)
                 stat_in = tr.input
                 stat_out = tr.output
-        stat_out = stat_out[0] if type(stat_out) is tuple else stat_out
+        stat_out = nethook.get_hidden_state(stat_out)
 
 
 

--- a/easyeditor/util/alg_dict.py
+++ b/easyeditor/util/alg_dict.py
@@ -17,6 +17,7 @@ from ..models.wise import WISEHyperParams, apply_wise_to_model, apply_wise_to_mu
 from ..models.r_rome import R_ROMEHyperParams, apply_r_rome_to_model
 from ..models.emmet import EMMETHyperParams, apply_emmet_to_model
 from ..models.alphaedit import AlphaEditHyperParams, apply_AlphaEdit_to_model
+from ..models.SPHERE import SPHEREHyperParams, apply_SPHERE_to_model
 from ..models.core import COREHyperParams, apply_core_to_model
 from .. models.deepedit_api import DeepEditApiHyperParams, apply_deepedit_api_to_model
 from ..models.dpo import DPOHyperParams, apply_dpo_to_model
@@ -44,6 +45,7 @@ ALG_DICT = {
     'R-ROME': apply_r_rome_to_model,
     "EMMET": apply_emmet_to_model,
     "AlphaEdit": apply_AlphaEdit_to_model,
+    "SPHERE": apply_SPHERE_to_model,
     "ULTRAEDIT": UltraEditRewriteExecutor().apply_to_model,
     "CORE": apply_core_to_model,
     "DeepEdit-Api": apply_deepedit_api_to_model,

--- a/easyeditor/util/logit_lens.py
+++ b/easyeditor/util/logit_lens.py
@@ -63,7 +63,7 @@ class LogitLens:
 
         with torch.no_grad():
             for layer, (_, t) in enumerate(self.td.items()):
-                cur_out = t.output[0]
+                cur_out = nethook.get_hidden_state(t.output)
                 assert (
                     cur_out.size(0) == 1
                 ), "Make sure you're only running LogitLens on single generations only."

--- a/easyeditor/util/nethook.py
+++ b/easyeditor/util/nethook.py
@@ -68,7 +68,7 @@ class Trace(contextlib.AbstractContextManager):
         if layer is not None:
             module = get_module(module, layer)
 
-        def retain_hook(m, inputs, output, kwargs=None):
+        def retain_hook(m, inputs, kwargs, output):
             if retain_input:
                 # Try to get input from positional args first
                 if len(inputs) > 0:
@@ -114,7 +114,7 @@ class Trace(contextlib.AbstractContextManager):
         except TypeError:
             # Fallback for older PyTorch versions - wrap the hook to ignore kwargs parameter
             def legacy_hook(m, inputs, output):
-                return retain_hook(m, inputs, output, kwargs=None)
+                return retain_hook(m, inputs, None, output)
             self.registered_hook = module.register_forward_hook(legacy_hook)
         self.stop = stop
 
@@ -216,6 +216,39 @@ class StopForward(Exception):
     """
 
     pass
+
+
+def get_hidden_state(output):
+    """
+    Returns the primary hidden-state tensor from a transformer layer output.
+    Newer transformers decoder layers may return a tensor directly, while
+    older versions commonly returned a tuple whose first item is the tensor.
+    """
+    if isinstance(output, torch.Tensor):
+        return output
+    if isinstance(output, (list, tuple)):
+        if len(output) == 0:
+            raise ValueError("Cannot read hidden state from an empty layer output.")
+        return output[0]
+    raise TypeError(f"Unsupported layer output type: {type(output)}")
+
+
+def replace_hidden_state(output, hidden_state):
+    """
+    Replaces the primary hidden-state tensor while preserving the original
+    output container type when the layer returned a tuple/list.
+    """
+    if isinstance(output, torch.Tensor):
+        return hidden_state
+    if isinstance(output, list):
+        updated = list(output)
+        updated[0] = hidden_state
+        return updated
+    if isinstance(output, tuple):
+        updated = list(output)
+        updated[0] = hidden_state
+        return type(output)(updated)
+    raise TypeError(f"Unsupported layer output type: {type(output)}")
 
 
 def recursive_copy(x, clone=None, detach=None, retain_grad=None):


### PR DESCRIPTION
Fixes PyTorch 2.x forward hook kwargs ordering and supports transformer layers returning hidden states directly instead of tuples. Tested on Qwen2.5-1.5B with ROME/R-ROME/FT/LoRA/GRACE/KN and
    smoke-tested MEMIT/EMMET/PMET/CORE/AlphaEdit/SPHERE compute_z paths.