### PR TITLE
Normalize legacy hparams algorithm fields

### DIFF
--- a/easyeditor/dataset/ComprehendEdit.py
+++ b/easyeditor/dataset/ComprehendEdit.py
@@ -135,8 +135,6 @@ class ComprehendEditDataset(BaseDataset):
                 data.append(item)
             # torch.save(data, path)
 
-        if not hasattr(self.config, 'alg'):
-            self.config.alg = self.config.alg_name
         if self.mode != 'train' and self.topk != -1:
             self.test_ = True
         else:

--- a/easyeditor/dataset/counterfact.py
+++ b/easyeditor/dataset/counterfact.py
@@ -140,7 +140,7 @@ class CounterFactDataset(Dataset):
 
 
     def collate_gpt_fn(self, batch):
-        if self.config.alg =='SERAC' and 'gpt' in self.config.model_name.lower():
+        if self.config.alg_name == 'SERAC' and 'gpt' in self.config.model_name.lower():
             src = [b["prompt"] for b in batch]
             trg = [' ' + b["target_new"] for b in batch]
             cond = ["{} >> {} || {}".format(b['ground_truth'],

--- a/easyeditor/models/malmen/malmen_hparams.py
+++ b/easyeditor/models/malmen/malmen_hparams.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -18,7 +17,6 @@ class MALMENHyperParams(HyperParams):
     archive: Any
 
     # Method
-    alg: str
     debug: bool
     dropout: float
     train_base: bool
@@ -62,15 +60,8 @@ class MALMENHyperParams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-        assert (config and config['alg'] == 'MALMEN') or print(f'MALMENTrainingHyperParams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "MALMEN")
         config['val_batch_size'] = config['batch_size']
         return cls(**config)
     

--- a/easyeditor/models/mend/mend_hparams.py
+++ b/easyeditor/models/mend/mend_hparams.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -15,7 +14,6 @@ class MENDHyperParams(HyperParams):
     archive: Any
 
     # Method
-    alg: str
     lr: float
     edit_lr: float
     lr_lr: float
@@ -80,13 +78,6 @@ class MENDHyperParams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-        assert (config and config['alg'] == 'MEND') or print(f'MENDHyperParams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "MEND")
         return cls(**config)

--- a/easyeditor/models/mend/mend_multimodal_hparams.py
+++ b/easyeditor/models/mend/mend_multimodal_hparams.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from .mend_hparams import MENDHyperParams
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -27,7 +26,6 @@ class MENDMultimodalHparams(HyperParams):
     archive: Any
 
     # Method
-    alg: str
     lr: float
     edit_lr: float
     lr_lr: float
@@ -94,14 +92,6 @@ class MENDMultimodalHparams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-        assert (config and config['alg'] == 'MEND') or print(f'MENDMultimodalHyperParams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "MEND")
         return cls(**config)
-

--- a/easyeditor/models/serac/serac_hparams.py
+++ b/easyeditor/models/serac/serac_hparams.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -19,7 +18,6 @@ class SERACHparams(HyperParams):
     archive: Any
 
     # Method
-    alg: str
     lr: float
     edit_lr: float
     seed: int
@@ -82,13 +80,6 @@ class SERACHparams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-        assert (config and config['alg'] == 'SERAC') or print(f'SERACTrainingHyperParams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "SERAC")
         return cls(**config)

--- a/easyeditor/models/serac/serac_multimodal_hparams.py
+++ b/easyeditor/models/serac/serac_multimodal_hparams.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -29,7 +28,6 @@ class SERACMultimodalHparams(HyperParams):
     archive: Any
 
     # Method
-    alg: str
     alg_name: str
     lr: float
     edit_lr: float
@@ -95,14 +93,6 @@ class SERACMultimodalHparams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-
-        assert (config and config['alg'] == 'SERAC_MULTI') or print(f'SERACMultimodalHparams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "SERAC_MULTI")
         return cls(**config)

--- a/easyeditor/models/ultraedit/ultraedit_hparams.py
+++ b/easyeditor/models/ultraedit/ultraedit_hparams.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 from typing import Optional, Any, List
-import yaml
 
 
 @dataclass
@@ -17,7 +16,6 @@ class UltraEditHyperParams(HyperParams):
     device: int
 
     # Method
-    alg: str
     dropout: float
     no_grad_layers: Any
     batch_size: int
@@ -38,14 +36,19 @@ class UltraEditHyperParams(HyperParams):
     @classmethod
     def from_hparams(cls, hparams_name_or_path: str):
 
-        if '.yaml' not in hparams_name_or_path:
-            hparams_name_or_path = hparams_name_or_path + '.yaml'
-
-        with open(hparams_name_or_path, "r") as stream:
-            config = yaml.safe_load(stream)
-            config = super().construct_float_from_scientific_notation(config)
-
-        assert (config and config['alg_name'] == 'ULTRAEDIT') or print(f'ULTRAEDITTrainingHyperParams can not load from {hparams_name_or_path}, '
-                                                f'alg_name is {config["alg_name"]} ')
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(
+            config,
+            "ULTRAEDIT",
+            aliases={"UltraEdit": "ULTRAEDIT"},
+        )
+        class_name = config.pop("class_name", None)
+        if class_name is not None:
+            if "model_class" not in config:
+                config["model_class"] = class_name
+            elif config["model_class"] != class_name:
+                raise ValueError(
+                    "ULTRAEDIT hparams define conflicting model_class and class_name."
+                )
         return cls(**config)
     

--- a/easyeditor/util/hparams.py
+++ b/easyeditor/util/hparams.py
@@ -2,6 +2,8 @@ import json
 from dataclasses import dataclass
 from dataclasses import asdict
 
+import yaml
+
 
 @dataclass
 class HyperParams:
@@ -29,18 +31,69 @@ class HyperParams:
     def to_dict(config) -> dict:
         dict = asdict(config)
         return dict
-            
-        
 
-    # @classmethod
-    # def from_hparams(cls, hparams_name_or_path: str):
-    #
-    #     if '.yaml' not in hparams_name_or_path:
-    #         hparams_name_or_path = hparams_name_or_path + '.yaml'
-    #     config = compose(hparams_name_or_path)
-    #
-    #     assert config.alg_name in ALG_DICT.keys() or print(f'Editing Alg name {config.alg_name} not supported yet.')
-    #
-    #     params_class, apply_algo = ALG_DICT[config.alg_name]
-    #
-    #     return params_class(**config)
+
+def load_hparams_config(hparams_name_or_path: str) -> dict:
+    hparams_path = str(hparams_name_or_path)
+    if not hparams_path.endswith((".yaml", ".yml", ".json")):
+        hparams_path = hparams_path + ".yaml"
+
+    with open(hparams_path, "r") as stream:
+        if hparams_path.endswith(".json"):
+            config = json.load(stream)
+        else:
+            config = yaml.safe_load(stream)
+
+    if config is None:
+        return config
+    if not isinstance(config, dict):
+        raise ValueError(f"hparams config must be a mapping: {hparams_path}")
+    return HyperParams.construct_float_from_scientific_notation(config)
+
+
+def normalize_alg_name(
+    config: dict,
+    expected_alg_name: str,
+    *,
+    aliases: dict = None,
+    legacy_key: str = "alg",
+    keep_legacy: bool = False,
+    legacy_value: str = None,
+) -> dict:
+    if not config:
+        raise ValueError(f"{expected_alg_name} hparams config is empty.")
+
+    aliases = aliases or {}
+
+    def canonical(value):
+        if value is None:
+            return None
+        value = str(value)
+        return aliases.get(value, value)
+
+    present = [
+        (key, config.get(key), canonical(config.get(key)))
+        for key in ("alg_name", legacy_key)
+        if config.get(key) is not None
+    ]
+    if not present:
+        raise ValueError(
+            f"{expected_alg_name} hparams must define alg_name or {legacy_key}."
+        )
+
+    invalid = [
+        f"{key}={value!r}"
+        for key, value, name in present
+        if name != expected_alg_name
+    ]
+    if invalid:
+        details = ", ".join(invalid)
+        raise ValueError(f"{expected_alg_name} hparams can not load with {details}.")
+
+    config["alg_name"] = expected_alg_name
+    if keep_legacy:
+        if legacy_key not in config or config.get(legacy_key) is None:
+            config[legacy_key] = legacy_value or expected_alg_name
+    else:
+        config.pop(legacy_key, None)
+    return config

--- a/hparams/MALMEN/gpt2-xl.yaml
+++ b/hparams/MALMEN/gpt2-xl.yaml
@@ -15,7 +15,6 @@ inner_params:
 - transformer.h.47.mlp.c_proj.weight
 
 # Method
-alg: MALMEN
 dropout: 0.0
 train_base: False
 no_grad_layers: null

--- a/hparams/MEND/baichuan-7b.yaml
+++ b/hparams/MEND/baichuan-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/blip2.yaml
+++ b/hparams/MEND/blip2.yaml
@@ -15,7 +15,6 @@ inner_params:
 - opt_model.model.decoder.layers.31.fc2.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/chatglm2-6b.yaml
+++ b/hparams/MEND/chatglm2-6b.yaml
@@ -18,7 +18,6 @@ inner_params:
 - transformer.encoder.layers.27.mlp.dense_4h_to_h.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/gpt-j-6B.yaml
+++ b/hparams/MEND/gpt-j-6B.yaml
@@ -18,7 +18,6 @@ inner_params:
 - transformer.h.27.mlp.fc_out.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/gpt2-xl-instruct.yaml
+++ b/hparams/MEND/gpt2-xl-instruct.yaml
@@ -17,7 +17,6 @@ inner_params:
 - transformer.h.47.mlp.c_fc.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/gpt2-xl.yaml
+++ b/hparams/MEND/gpt2-xl.yaml
@@ -18,7 +18,6 @@ inner_params:
 - transformer.h.47.mlp.c_fc.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/internlm-7b.yaml
+++ b/hparams/MEND/internlm-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/llama-7b-instruct-detoxifying.yaml
+++ b/hparams/MEND/llama-7b-instruct-detoxifying.yaml
@@ -20,7 +20,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/llama-7b-instruct.yaml
+++ b/hparams/MEND/llama-7b-instruct.yaml
@@ -20,7 +20,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/llama-7b.yaml
+++ b/hparams/MEND/llama-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/llama3-8b.yaml
+++ b/hparams/MEND/llama3-8b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/minigpt4.yaml
+++ b/hparams/MEND/minigpt4.yaml
@@ -15,7 +15,6 @@ inner_params:
 - llama_model.model.layers.31.mlp.up_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/mistral-7b-detoxifying.yaml
+++ b/hparams/MEND/mistral-7b-detoxifying.yaml
@@ -21,7 +21,6 @@ inner_params:
   - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/mistral-7b.yaml
+++ b/hparams/MEND/mistral-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
   - model.layers.31.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/qwen-7b.yaml
+++ b/hparams/MEND/qwen-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - transformer.h.31.mlp.c_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/qwen2-7b.yaml
+++ b/hparams/MEND/qwen2-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.27.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/qwen2.5-7b.yaml
+++ b/hparams/MEND/qwen2.5-7b.yaml
@@ -21,7 +21,6 @@ inner_params:
 - model.layers.27.mlp.down_proj.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/MEND/t5-3B.yaml
+++ b/hparams/MEND/t5-3B.yaml
@@ -20,7 +20,6 @@ inner_params:
 - decoder.block.23.layer.2.DenseReluDense.wo.weight
 
 # Method
-alg: MEND
 lr: 1e-6
 edit_lr: 1e-4
 lr_lr: 1e-4

--- a/hparams/SERAC/baichuan.yaml
+++ b/hparams/SERAC/baichuan.yaml
@@ -14,7 +14,6 @@ inner_params: []
 model_parallel: false
 
 # Method
-alg: SERAC
 lr: 1e-5
 edit_lr: 1e-2
 seed: 0

--- a/hparams/SERAC/blip2.yaml
+++ b/hparams/SERAC/blip2.yaml
@@ -18,7 +18,6 @@ inner_params:
 - opt_model.model.decoder.layers.31.fc2.weight
 
 # Method
-alg: SERAC_MULTI
 alg_name: SERAC_MULTI
 lr: 1e-5
 edit_lr: 1e-2

--- a/hparams/SERAC/gpt-j-6B.yaml
+++ b/hparams/SERAC/gpt-j-6B.yaml
@@ -14,7 +14,6 @@ inner_params: []
 model_parallel: false
 
 # Method
-alg: SERAC
 lr: 1e-5
 edit_lr: 1e-2
 seed: 0

--- a/hparams/SERAC/gpt2-xl.yaml
+++ b/hparams/SERAC/gpt2-xl.yaml
@@ -14,7 +14,6 @@ inner_params: []
 model_parallel: false
 
 # Method
-alg: SERAC
 lr: 1e-5
 edit_lr: 1e-2
 seed: 0

--- a/hparams/SERAC/llama-7b.yaml
+++ b/hparams/SERAC/llama-7b.yaml
@@ -14,7 +14,6 @@ inner_params: []
 model_parallel: false
 
 # Method
-alg: SERAC
 lr: 1e-5
 edit_lr: 1e-2
 seed: 0

--- a/hparams/SERAC/minigpt4.yaml
+++ b/hparams/SERAC/minigpt4.yaml
@@ -18,7 +18,6 @@ inner_params:
 - llama_model.model.layers.31.mlp.up_proj.weight
 
 # Method
-alg: SERAC_MULTI
 alg_name: SERAC_MULTI
 lr: 1e-5
 edit_lr: 1e-2

--- a/hparams/SERAC/t5-3B.yaml
+++ b/hparams/SERAC/t5-3B.yaml
@@ -14,7 +14,6 @@ inner_params: []
 model_parallel: false
 
 # Method
-alg: SERAC
 lr: 1e-5
 edit_lr: 1e-2
 seed: 0

--- a/hparams/UltraEdit/gemma-3-27b.yaml
+++ b/hparams/UltraEdit/gemma-3-27b.yaml
@@ -27,7 +27,6 @@ inner_params:
 - language_model.model.layers.60.mlp.up_proj
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 

--- a/hparams/UltraEdit/gpt-j-6B.yaml
+++ b/hparams/UltraEdit/gpt-j-6B.yaml
@@ -30,7 +30,6 @@ inner_params:
 # - transformer.h.26.mlp.fc_out
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 

--- a/hparams/UltraEdit/llama3-8b-instruct.yaml
+++ b/hparams/UltraEdit/llama3-8b-instruct.yaml
@@ -40,7 +40,6 @@ inner_params:
 # - model.layers.30.mlp.up_proj
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 

--- a/hparams/UltraEdit/mistral-7b.yaml
+++ b/hparams/UltraEdit/mistral-7b.yaml
@@ -12,7 +12,6 @@ inner_params:
 - model.layers.30.mlp.down_proj
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 

--- a/hparams/UltraEdit/phi-4.yaml
+++ b/hparams/UltraEdit/phi-4.yaml
@@ -18,7 +18,6 @@ inner_params:
 - model.layers.38.mlp.down_proj
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 

--- a/hparams/UltraEdit/qwen2.5-7b.yaml
+++ b/hparams/UltraEdit/qwen2.5-7b.yaml
@@ -45,7 +45,6 @@ inner_params:
 # - model.layers.26.mlp.up_proj
 
 # Method
-alg: UltraEdit
 dropout: 0.0
 no_grad_layers: null
 


### PR DESCRIPTION
## Summary
- add shared helpers for hparams loading and edit-side algorithm-name normalization
- make `alg_name` the only algorithm tag persisted in edit hparams configs and edit hparams objects
- keep legacy `alg` as a load-time alias for external old YAML, then drop it before dataclass construction
- remove duplicate `alg` keys from repository edit YAMLs for MEND, SERAC, MALMEN, and UltraEdit
- leave `hparams/TRAINING` and trainer `config.alg` behavior unchanged
- support UltraEdit legacy aliases: `alg: UltraEdit` -> `alg_name: ULTRAEDIT`, and `class_name` -> `model_class`
- update edit-side dataset code that still read or wrote `config.alg`

## Validation
- `git diff --check`
- `py_compile` for all changed source files
- no-GPU hparams loading checks for all 32 target YAML files under `hparams/MEND`, `hparams/SERAC`, `hparams/MALMEN`, and `hparams/UltraEdit`
- checks that repository edit YAMLs no longer contain `alg` and loaded edit hparams no longer expose a legacy `alg` field
- checks that training YAMLs still keep their `alg` keys
- synthetic compatibility checks for `alg_name` only, legacy `alg` only, UltraEdit aliases, conflict errors, and non-mapping config errors
- CounterFact SERAC branch check with `alg_name` only

Validation log on Falcon:
`/mnt/20t/xuhaoming/yfy/logs/hparams-normalization-20260607.log`