### PR TITLE
[codex] Normalize EasyEdit device handling

### DIFF
--- a/easyeditor/editors/concept_editor.py
+++ b/easyeditor/editors/concept_editor.py
@@ -15,6 +15,7 @@ from ..evaluate import compute_concept_edit_quality
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import copy_to_param, normalize_device
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt = '%m/%d/%Y %H:%M:%S',
@@ -128,10 +129,9 @@ class ConceptEditor:
         else:
             self.model, self.tok = self.model_name
 
-        if hparams.model_parallel:
-            hparams.device = str(self.model.device).split(":")[1]
+        self.device = normalize_device(getattr(hparams, "device", None))
         if not hparams.model_parallel and hasattr(hparams, 'device'):
-            self.model.to(f'cuda:{hparams.device}')
+            self.model.to(self.device)
 
         self.hparams = hparams
 
@@ -224,7 +224,7 @@ class ConceptEditor:
                 })
                 with torch.no_grad():
                     for k, v in weights_copy.items():
-                        nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                        copy_to_param(nethook.get_parameter(self.model, k), v)
             if 'locality' in all_metrics[i]['post'].keys():
                 for locality_key in request['locality'].keys():
                     assert len(all_metrics[i]['post']['locality'][f'{locality_key}_output']) == \

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -17,6 +17,7 @@ from ..evaluate import compute_edit_quality, compute_icl_edit_quality, compute_s
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import copy_to_param, move_to_device, normalize_device
 from ..evaluate.evaluate_utils import test_generation_quality
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
@@ -137,10 +138,9 @@ class BaseEditor:
         else:
             self.model, self.tok = self.model_name
 
-        if hparams.model_parallel: 
-            hparams.device = str(self.model.device).split(":")[1]
-        if not hparams.model_parallel and hasattr(hparams, 'device') and hparams.alg_name != 'QLoRA':
-            self.model.to(f'cuda:{hparams.device}')
+        self.device = normalize_device(getattr(hparams, "device", None))
+        if self.model is not None and not hparams.model_parallel and hparams.alg_name != 'QLoRA':
+            self.model.to(self.device)
 
         self.hparams = hparams
 
@@ -262,7 +262,7 @@ class BaseEditor:
                 else:
                     with torch.no_grad():
                         for k, v in weights_copy.items():
-                            nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                            copy_to_param(nethook.get_parameter(self.model, k), v)
 
             for i, request in enumerate(record_chunks):
                 chunk_metrics[i]["pre"] = compute_edit_quality(self.model, self.model_name, self.hparams, self.tok, request, self.hparams.device, test_generation=test_generation)
@@ -407,7 +407,7 @@ class BaseEditor:
                 else:
                     with torch.no_grad():
                         for k, v in weights_copy.items():
-                            nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                            copy_to_param(nethook.get_parameter(self.model, k), v)
 
 
         if isinstance(edited_model, LORA):
@@ -459,7 +459,7 @@ class BaseEditor:
 
         with torch.no_grad():
             for k, v in weights_copy.items():
-                nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                copy_to_param(nethook.get_parameter(self.model, k), v)
 
         return None, edited_model, weights_copy
     
@@ -508,7 +508,7 @@ class BaseEditor:
                 tokenize=False,
                 add_generation_prompt=True,
             )
-            model_inputs = tok.encode(text, return_tensors="pt").to(f"cuda:{device}")
+            model_inputs = move_to_device(tok.encode(text, return_tensors="pt"), device)
             template_length = len(model_inputs[0])
             generated_ids = model.generate(
                 input_ids=model_inputs,
@@ -622,7 +622,7 @@ class BaseEditor:
                 else:
                     with torch.no_grad():
                         for k, v in weights_copy.items():
-                            nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                            copy_to_param(nethook.get_parameter(self.model, k), v)
 
         if isinstance(edited_model, LORA):
             edited_model = edited_model.model

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -30,6 +30,7 @@ from ..evaluate import (compute_icl_multimodal_edit_quality,
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import copy_to_param, normalize_device
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt = '%m/%d/%Y %H:%M:%S',
@@ -162,7 +163,8 @@ class MultimodalEditor:
         else:
             self.model, self.tok = self.model_name
             
-        self.model.to(f'cuda:{hparams.device}')
+        self.device = normalize_device(getattr(hparams, "device", None))
+        self.model.to(self.device)
         self.hparams = hparams
 
     def edit(self,
@@ -437,7 +439,7 @@ class MultimodalEditor:
                 else:
                     with torch.no_grad():
                         for k, v in weights_copy.items():
-                            nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                            copy_to_param(nethook.get_parameter(self.model, k), v)
 
                 all_metrics.append(metrics)
 

--- a/easyeditor/editors/per_editor.py
+++ b/easyeditor/editors/per_editor.py
@@ -22,6 +22,7 @@ from ..evaluate import (
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import normalize_device
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt = '%m/%d/%Y %H:%M:%S',
@@ -85,31 +86,29 @@ class PerEditor:
         else:
             self.model, self.tok = self.model_name
 
-        if hparams.model_parallel:
-            hparams.device = str(self.model.device).split(":")[1]
+        self.device = normalize_device(getattr(hparams, "device", None))
         if not hparams.model_parallel and hasattr(hparams, 'device'):
-            self.model.to(f'cuda:{hparams.device}')
-            self.device = hparams.device
+            self.model.to(self.device)
 
         self.hparams = hparams
-        
-        
+
+
     def edit_dataset(self, ds: Dataset, keep_original_weight=False, verbose=True):
         """edit for IKE in Personality Dataset"""
         # Make Sure dataset supportedxiao
         assert sum([isinstance(ds, ds_in_dict) for ds_in_dict in PER_DS_DICT.values()]) > 0, print(f'DataSet {ds} not supported yet.')
-                
+
         all_metrics = []
         collate_fn = ds.collate_gpt_fn
         for i, request in enumerate(tqdm(ds, desc='Editing dataset', total=len(ds))):
             start = time()
-            
+
             if self.alg_name == 'IKE':
                 edited_model, weights_copy = self.model, {}
                 outer_idx = (i + 1) % len(ds)
                 loc_case = ds[outer_idx]
                 example = self.apply_algo(request=request, loc_request=loc_case, tokenizer=self.tok, device=self.device)
-                
+
                 exec_time = time() - start
                 LOG.info(f"Execution {i} editing took {exec_time}")
                 start = time()
@@ -124,7 +123,7 @@ class PerEditor:
                     )
 
                 all_metrics.append(metrics)
-                
+
             else:
                 example = collate_fn([request])
                 edited_model, weights_copy = self.apply_algo(
@@ -134,7 +133,7 @@ class PerEditor:
                     hparams=self.hparams,
                     device=self.device,
                 )
-                
+
                 exec_time = time() - start
                 LOG.info(f"Execution {i} editing took {exec_time}")
                 start = time()
@@ -142,16 +141,16 @@ class PerEditor:
                     'case_id': i,
                     "time": exec_time,
                 }
-                
+
                 metrics.update(compute_per_metric(example=example, model=self.model, edited_model=edited_model, tok=self.tok, device=self.device, test_generation=True))
                 if verbose:
                     LOG.info(
                         f"{i} editing: {request['ent']} -> {request['target_personality']}  \n {metrics}"
                     )
-                    
+
                 all_metrics.append(metrics)
 
 
         return all_metrics, edited_model, weights_copy
-    
-    
+
+

--- a/easyeditor/editors/safety_editor.py
+++ b/easyeditor/editors/safety_editor.py
@@ -14,6 +14,7 @@ from ..evaluate import compute_safety_edit_quality
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import copy_to_param, move_to_device, normalize_device
 
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
@@ -87,10 +88,9 @@ class SafetyEditor:
         else:
             self.model, self.tok = self.model_name
 
-        if hparams.model_parallel:
-            hparams.device = str(self.model.device).split(":")[1]
+        self.device = normalize_device(getattr(hparams, "device", None))
         if not hparams.model_parallel and hasattr(hparams, 'device'):
-            self.model.to(f'cuda:{hparams.device}')
+            self.model.to(self.device)
 
         self.hparams = hparams
 
@@ -101,7 +101,7 @@ class SafetyEditor:
         # else:
         #     tokenizer.padding_side = 'left'
         toxic_layer = []
-        input = tokenizer([value for pair in requests for value in [pair["target_new"], pair["ground_truth"]]], return_tensors="pt", padding=True, truncation=True).to(f"cuda:{self.hparams.device}") 
+        input = move_to_device(tokenizer([value for pair in requests for value in [pair["target_new"], pair["ground_truth"]]], return_tensors="pt", padding=True, truncation=True), self.hparams.device)
         with torch.no_grad():
             outputs = model(**input)
         hidden_states = outputs.hidden_states
@@ -210,7 +210,7 @@ class SafetyEditor:
                 
                 with torch.no_grad():
                     for k, v in weights_copy.items():
-                        nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                        copy_to_param(nethook.get_parameter(self.model, k), v)
                 
 
                 LOG.info(f"Evaluation took {time() - start}")
@@ -245,7 +245,7 @@ class SafetyEditor:
                 
                 with torch.no_grad():
                     for k, v in weights_copy.items():
-                        nethook.get_parameter(self.model, k)[...] = v.to(f"cuda:{self.hparams.device}")
+                        copy_to_param(nethook.get_parameter(self.model, k), v)
                 
 
                 LOG.info(f"Evaluation took {time() - start}")

--- a/easyeditor/editors/steer_editor.py
+++ b/easyeditor/editors/steer_editor.py
@@ -20,6 +20,7 @@ from ..evaluate import compute_safety_edit_quality
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
+from ..util.device import normalize_device
 
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
@@ -46,7 +47,7 @@ def seed_everything(seed):
     torch.manual_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
-    
+
 seed_everything(42)
 
 
@@ -64,31 +65,31 @@ class SteerEditor:
 
         self.model_name = hparams.model_name
         self.alg_name = hparams.alg_name
-        self.modal_type = None # llm or mllm 
-        
+        self.modal_type = None # llm or mllm
+
         make_logs()
 
         LOG.info("Instantiating model")
-        
+
 
         if type(self.model_name) is str:
             device_map = 'auto' if hparams.model_parallel else None
             torch_dtype = torch.float16 if hasattr(hparams, 'fp16') and hparams.fp16 else torch.float32
-            
+
             if 'llama' in self.model_name.lower():
                 self.model = LlamaForCausalLM.from_pretrained(self.model_name, output_hidden_states=True, torch_dtype=torch_dtype, device_map=device_map)
                 self.tok = LlamaTokenizer.from_pretrained(self.model_name)
-                self.tok.pad_token_id = self.tok.eos_token_id 
+                self.tok.pad_token_id = self.tok.eos_token_id
                 self.modal_type = 'llm'
             elif 'mistral' in self.model_name.lower():
                 self.model = AutoModelForCausalLM.from_pretrained(self.model_name, output_hidden_states=True, torch_dtype=torch_dtype, device_map=device_map)
                 self.tok = AutoTokenizer.from_pretrained(self.model_name)
-                self.tok.pad_token_id = self.tok.eos_token_id 
+                self.tok.pad_token_id = self.tok.eos_token_id
                 self.modal_type = 'llm'
             elif 'gpt' in self.model_name.lower():
                 self.model = AutoModelForCausalLM.from_pretrained(self.model_name, output_hidden_states=True, torch_dtype=torch_dtype, device_map=device_map)
                 self.tok = GPT2Tokenizer.from_pretrained(self.model_name)
-                self.tok.pad_token_id = self.tok.eos_token_id    
+                self.tok.pad_token_id = self.tok.eos_token_id
                 self.modal_type = 'llm'
             elif 'llava' in self.model_name.lower():
                 self.model = LlavaForConditionalGeneration.from_pretrained(self.model_name, output_hidden_states=True, torch_dtype=torch_dtype, device_map=device_map)
@@ -103,42 +104,40 @@ class SteerEditor:
         else:
             self.model, self.tok = self.model_name
 
-        if hparams.model_parallel:
-            hparams.device = str(self.model.device).split(":")[1]
+        self.device = normalize_device(getattr(hparams, "device", None))
         if not hparams.model_parallel and hasattr(hparams, 'device'):
-            self.model.to(f'cuda:{hparams.device}')
+            self.model.to(self.device)
 
         self.hparams = hparams
-        self.device = torch.device(f'cuda:{hparams.device}')
-        
+
         if self.modal_type == 'llm':
             self.lm_head = self.model.get_output_embeddings()
             self.norm = self.model.model.norm
         else:
             self.lm_head = self.model.language_model.get_output_embeddings()
             self.norm = self.model.language_model.model.norm
-    
-    
-    def generate(self, 
-                 input_text: str = None, 
+
+
+    def generate(self,
+                 input_text: str = None,
                  input_image: str = None,
                  temperature: float = None,
                  **model_kwargs
                 ):
         assert (input_image is not None and self.modal_type == 'mllm') or (input_image is None and self.modal_type == 'llm'), print('Error: llm cannot process image input or input_image is None.')
-        
+
         if self.modal_type == 'llm':
             inputs = self.tok(input_text, return_tensors="pt").to(self.device)
         else:
             input_image = Image.open(input_image).convert("RGB")
             inputs = self.tok(images=input_image, text=input_text, return_tensors="pt").to(self.device)
-            
+
         # constrained decoding methods: dola, deco, opera, vcd
         if self.alg_name == 'dola':
             transformers.generation.utils.GenerationMixin.generate = dola_generate
             outputs = self.model.generate(
-                                        **inputs, 
-                                        do_sample=False, 
+                                        **inputs,
+                                        do_sample=False,
                                         dola_layers=self.hparams.dola_layers,
                                         final_layer=self.hparams.final_layer,
                                         lm_head=self.lm_head,
@@ -147,7 +146,7 @@ class SteerEditor:
         elif self.alg_name == 'deco':
             transformers.generation.utils.GenerationMixin.generate = deco_generate
             outputs = self.model.generate(
-                                        **inputs, 
+                                        **inputs,
                                         do_sample=True if temperature > 0 else False,
                                         alpha=self.hparams.alpha,
                                         threshold_top_p=self.hparams.threshold_top_p,
@@ -160,14 +159,14 @@ class SteerEditor:
         # base decoding methods
         else:
             outputs = self.model.generate(
-                                        **inputs, 
+                                        **inputs,
                                         do_sample=True if temperature > 0 else False,
                                         **model_kwargs
                                         )
-        
-        
+
+
         output_text = self.tok.batch_decode(outputs[:, inputs.input_ids.shape[-1]:], skip_special_tokens=True)
         return output_text
-        
-        
-        
+
+
+

--- a/easyeditor/evaluate/evaluate.py
+++ b/easyeditor/evaluate/evaluate.py
@@ -14,6 +14,7 @@ import torch
 # from sklearn.feature_extraction.text import TfidfVectorizer
 from transformers import AutoTokenizer
 from ..util import HyperParams
+from ..util.device import normalize_device
 from .evaluate_utils import (
     test_seq2seq_batch_prediction_acc, 
     test_batch_prediction_acc, 
@@ -335,7 +336,7 @@ def icl_lm_eval(
         x,
         neighborhood=False
 )-> typing.Dict:
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     if 't5' in model_name.lower():
         target_len = len(tokenizer.encode(target))
         target_ids = tokenizer(f'{x} {target}', return_tensors='pt')['input_ids'].to(device)

--- a/easyeditor/evaluate/evaluate_uns.py
+++ b/easyeditor/evaluate/evaluate_uns.py
@@ -5,6 +5,7 @@ from nltk.translate.bleu_score import corpus_bleu, sentence_bleu
 from rouge import Rouge
 from sentence_transformers import SentenceTransformer, util
 from tqdm import tqdm
+from ..util.device import normalize_device
 
 def eval_akew_unstructured(result_path, dataset_type, model_path='all-MiniLM-L6-v2', device=4):
     if not path.exists(result_path):
@@ -99,7 +100,7 @@ def eval_akew_unstructured(result_path, dataset_type, model_path='all-MiniLM-L6-
     sentences2 = [i['original_prediction'] for i in data]
     if dataset_type in ['unke','cf','wikiupdate','mquake']:
         sentences3 = [i['para_prediction'] for i in data]
-    model = SentenceTransformer(model_path, device=f"cuda:{device}")
+    model = SentenceTransformer(model_path, device=str(normalize_device(device)))
 
     embeddings1 = model.encode(sentences1, convert_to_tensor=True, show_progress_bar=True)
     embeddings2 = model.encode(sentences2, convert_to_tensor=True, show_progress_bar=True)

--- a/easyeditor/evaluate/evaluate_utils.py
+++ b/easyeditor/evaluate/evaluate_utils.py
@@ -13,6 +13,7 @@ from transformers import T5ForConditionalGeneration
 import time
 import regex
 import string
+from ..util.device import normalize_device
 
 
 def normalize_answer(s):
@@ -121,7 +122,7 @@ def test_prediction_acc_LLM_judge(model, tok, hparams, prompts, targets, device,
             padding = True,
             truncation = True,
             return_tensors="pt",
-        ).to(f"cuda:{device}")
+        ).to(normalize_device(device))
         # add a template
         gen_tokens = model.generate(
             input_ids=prompt_tok['input_ids'],
@@ -172,7 +173,7 @@ def test_batch_prediction_acc(model, tok, hparams, prompts, target, device, loca
         truncation=True,
         max_length=hparams.max_length,
         return_tensors="pt",
-    ).to(f"cuda:{device}")
+    ).to(normalize_device(device))
 
     with torch.no_grad():
         outputs = model(**prompt_tok)
@@ -205,7 +206,7 @@ def test_seq2seq_batch_prediction_acc(model, tok, hparams, prompts, targets, dev
         truncation=True,
         max_length=hparams.max_length,
         return_tensors="pt",
-    ).to(f"cuda:{device}")
+    ).to(normalize_device(device))
 
     trg_tok = tok(
         targets,
@@ -213,7 +214,7 @@ def test_seq2seq_batch_prediction_acc(model, tok, hparams, prompts, targets, dev
         truncation=True,
         max_length=hparams.max_length,
         return_tensors="pt",
-    ).to(f"cuda:{device}")
+    ).to(normalize_device(device))
 
     prompt_tok['decoder_input_ids'] = trg_tok['input_ids']
     prompt_tok['decoder_attention_mask'] = trg_tok['attention_mask']
@@ -242,7 +243,7 @@ def test_prediction_acc(model, tok, hparams, prompts, targets, device, locality=
             prompt_tok = tok(
                 prompt,
                 return_tensors="pt",
-            ).to(f"cuda:{device}")
+            ).to(normalize_device(device))
             gen_token = model.generate(
                 input_ids=prompt_tok['input_ids'],
                 attention_mask=prompt_tok['attention_mask'],
@@ -274,7 +275,7 @@ def test_prediction_acc(model, tok, hparams, prompts, targets, device, locality=
         truncation=True,
         max_length=max(hparams.max_length, max_prompt_len),
         return_tensors="pt",
-    ).to(f"cuda:{device}")
+    ).to(normalize_device(device))
     prompt_tok = tok(
         prompts,
         padding=True,
@@ -677,7 +678,7 @@ def F1(model, tok, hparams, prompts, targets, device, locality=False, vanilla_ge
         truncation=True,
         max_length=max(hparams.max_length, max_prompt_len),
         return_tensors="pt",
-    ).to(f"cuda:{device}")
+    ).to(normalize_device(device))
     prompt_tok = tok(
         prompts,
         padding=True,
@@ -721,8 +722,8 @@ def test_instance_change(model, tok, max_length, prompts, targets, device, P = N
     )
     with torch.no_grad():
         pre_edit_outputs = model.generate(
-            input_ids=prompt_tok['input_ids'].to(f"cuda:{device}"),
-            attention_mask=prompt_tok['attention_mask'].to(f"cuda:{device}"),
+            input_ids=prompt_tok['input_ids'].to(normalize_device(device)),
+            attention_mask=prompt_tok['attention_mask'].to(normalize_device(device)),
             max_new_tokens=2,
             pad_token_id=tok.eos_token_id
         )
@@ -754,8 +755,8 @@ def test_concept_gen(model, tok, max_length, prompts, targets, device):
     )
     with torch.no_grad():
         pre_edit_outputs = model.generate(
-            input_ids=prompt_tok['input_ids'].to(f"cuda:{device}"),
-            attention_mask=prompt_tok['attention_mask'].to(f"cuda:{device}"),
+            input_ids=prompt_tok['input_ids'].to(normalize_device(device)),
+            attention_mask=prompt_tok['attention_mask'].to(normalize_device(device)),
             max_new_tokens=40,
             pad_token_id=tok.eos_token_id
         )
@@ -777,7 +778,7 @@ def test_safety_gen(
     if max_tokens < 1624:
         only_response = []
         for item in test_prompt:
-            input = tokenizer([item,], return_tensors="pt", padding=True, truncation=True).to(f"cuda:{cuda}")
+            input = tokenizer([item,], return_tensors="pt", padding=True, truncation=True).to(normalize_device(cuda))
             if input["input_ids"].size(-1) > max_tokens-max_output_tokens:
                 input = {k: v[:, -(max_tokens - max_output_tokens):] for k, v in input.items()}
             with torch.no_grad():
@@ -792,7 +793,7 @@ def test_safety_gen(
             only_response.append(texts[len(overlap)+1:].lstrip())
         return only_response
     else:
-        input = tokenizer(test_prompt, return_tensors="pt", padding=True, truncation=True).to(f"cuda:{cuda}")
+        input = tokenizer(test_prompt, return_tensors="pt", padding=True, truncation=True).to(normalize_device(cuda))
         with torch.no_grad():
             outputs = model.generate(**input, max_new_tokens=max_output_tokens)
             texts = [tokenizer.decode(output, skip_special_tokens=True) for output in outputs]

--- a/easyeditor/evaluate/multimodal_evaluate.py
+++ b/easyeditor/evaluate/multimodal_evaluate.py
@@ -9,6 +9,7 @@ import torch
 # from sklearn.feature_extraction.text import TfidfVectorizer
 from transformers import AutoTokenizer, AutoProcessor
 from ..util import HyperParams
+from ..util.device import normalize_device
 from .evaluate_utils import (
     test_seq2seq_batch_prediction_acc,
     test_batch_prediction_acc,
@@ -52,20 +53,21 @@ def compute_icl_multimodal_edit_quality(
     """
     vis_root = hparams.coco_image
     rephrase_root = hparams.rephrase_image
+    target_device = normalize_device(device if device is not None else getattr(hparams, "device", None))
     # First, unpack rewrite evaluation record.
     target = record["target"]
     prompt = record["prompt"]
-    image = record["image"] if record["image"].is_cuda else record["image"].to(hparams.device)
+    image = record["image"] if record["image"].is_cuda else record["image"].to(target_device)
     rephrase = record["rephrase_prompt"] if 'rephrase_prompt' in record.keys() else None
     rephrase_image = record["image_rephrase"] if 'image_rephrase' in record.keys() else None
     if rephrase_image is not None:
-        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(hparams.device)
+        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(target_device)
 
     if "locality_prompt" in record.keys():
         loc_q = record["locality_prompt"]
         loc_a = record["locality_ground_truth"]
     if "multimodal_locality_image" in record.keys():
-        m_loc_image = record["multimodal_locality_image"] if record["multimodal_locality_image"].is_cuda else record["multimodal_locality_image"].to(hparams.device)
+        m_loc_image = record["multimodal_locality_image"] if record["multimodal_locality_image"].is_cuda else record["multimodal_locality_image"].to(target_device)
         m_loc_q = record["multimodal_locality_prompt"]
         m_loc_a = record["multimodal_locality_ground_truth"]
 
@@ -121,7 +123,7 @@ def icl_multimodal_lm_eval(
         image,
         is_loc=False,
         neighborhood=False )-> typing.Dict:
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
 
     samples = prepare_multimodal_edit(hparams, tokenizer, target, [''.join(icl_examples) + f'{x}'], image)
 
@@ -223,12 +225,13 @@ def prepare_multimodal_hf_edit(hparams,
     else:
         raise AssertionError("Not support file type: {}".format(file_type))
     
+    device = normalize_device(getattr(hparams, "device", None))
     if file_type in ["image", "single-image", "multi-image"]:
-        multimodal_inputs = processor(images=image, text=text_input, return_tensors="pt").to(hparams.device, dtype=hparams.dtype)
+        multimodal_inputs = processor(images=image, text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
     elif file_type == "video":
-        multimodal_inputs = processor(videos=image, text=text_input, return_tensors="pt").to(hparams.device, dtype=hparams.dtype)
+        multimodal_inputs = processor(videos=image, text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
     elif file_type == "text":
-        multimodal_inputs = processor(text=text_input, return_tensors="pt").to(hparams.device, dtype=hparams.dtype)
+        multimodal_inputs = processor(text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
     
     targets = processor.tokenizer(targets, add_special_tokens=False,
                      return_tensors="pt", padding=True, max_length=multimodal_inputs["input_ids"].size(1))["input_ids"]
@@ -397,19 +400,18 @@ def compute_multimodal_edit_results(
     :return: Dictionary containing rewriting metrics
     """
     ret = {}
+    target_device = normalize_device(device if device is not None else getattr(hparams, "device", None))
 
     target = record["target"]
     rewrite_prompts = record["prompt"]
-    # image = record["image"] if record["image"].is_cuda else record["image"].to(hparams.device)
-
     # 由于edit_dataset无prepare，因此request
     if hasattr(record["image"], 'is_cuda'):  # 如果是PyTorch张量
-        image = record["image"] if record["image"].is_cuda else record["image"].to(hparams.device)
+        image = record["image"] if record["image"].is_cuda else record["image"].to(target_device)
     else:  # 如果是PIL图像或其他类型
         # 需要先将PIL图像转换为张量
         from torchvision import transforms
         transform = transforms.ToTensor()
-        image = transform(record["image"]).to(hparams.device)
+        image = transform(record["image"]).to(target_device)
 
     edit_inner = prepare_multimodal_edit(hparams, tok, target, rewrite_prompts, image)
     ret['rewrite_acc'], _ = compute_multimodal_edit_quality(model, edit_inner)
@@ -421,7 +423,7 @@ def compute_multimodal_edit_results(
 
     if "image_rephrase" in record.keys():
         rephrase_image = record["image_rephrase"]
-        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(hparams.device)
+        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(target_device)
         edit_image_outer = prepare_multimodal_edit(hparams, tok, target, rewrite_prompts, rephrase_image)
         ret['image_rephrase_acc'], _ = compute_multimodal_edit_quality(model, edit_image_outer)
 
@@ -435,7 +437,7 @@ def compute_multimodal_edit_results(
         m_loc_prompt = record["multimodal_locality_prompt"]
         m_loc_ground_truth = record["multimodal_locality_ground_truth"]
         m_loc_image = record["multimodal_locality_image"]
-        m_loc_image = m_loc_image if m_loc_image.is_cuda else m_loc_image.to(hparams.device)
+        m_loc_image = m_loc_image if m_loc_image.is_cuda else m_loc_image.to(target_device)
         m_locality = prepare_multimodal_edit(hparams, tok, m_loc_ground_truth, m_loc_prompt, m_loc_image)
         _, _, ret['multimodal_locality_output'] = compute_multimodal_edit_quality_demo(model, m_locality)
     # Form a list of lists of prefixes to test.
@@ -522,10 +524,11 @@ def compute_multimodal_edit_results_demo(
     :return: Dictionary containing rewriting metrics
     """
     ret = {}
+    target_device = normalize_device(device if device is not None else getattr(hparams, "device", None))
 
     target = record["target"]
     rewrite_prompts = record["prompt"]
-    image = record["image"] if record["image"].is_cuda else record["image"].to(hparams.device)
+    image = record["image"] if record["image"].is_cuda else record["image"].to(target_device)
 
     edit_inner = prepare_multimodal_edit(hparams, tok, target, rewrite_prompts, image)
     ret['rewrite_acc'], _, logits = compute_multimodal_edit_quality_demo(model, edit_inner)
@@ -537,7 +540,7 @@ def compute_multimodal_edit_results_demo(
 
     if "image_rephrase" in record.keys():
         rephrase_image = record["image_rephrase"]
-        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(hparams.device)
+        rephrase_image = rephrase_image if rephrase_image.is_cuda else rephrase_image.to(target_device)
         edit_image_outer = prepare_multimodal_edit(hparams, tok, target, rewrite_prompts, rephrase_image)
         ret['image_rephrase_acc'], _ = compute_multimodal_edit_quality(model, edit_image_outer)
 
@@ -551,7 +554,7 @@ def compute_multimodal_edit_results_demo(
         m_loc_prompt = record["multimodal_locality_prompt"]
         m_loc_ground_truth = record["multimodal_locality_ground_truth"]
         m_loc_image = record["multimodal_locality_image"]
-        m_loc_image = m_loc_image if m_loc_image.is_cuda else m_loc_image.to(hparams.device)
+        m_loc_image = m_loc_image if m_loc_image.is_cuda else m_loc_image.to(target_device)
         m_locality = prepare_multimodal_edit(hparams, tok, m_loc_ground_truth, m_loc_prompt, m_loc_image)
         _, _, ret['multimodal_locality_output'] = compute_multimodal_edit_quality_demo(model, m_locality)
     # Form a list of lists of prefixes to test.

--- a/easyeditor/models/SPHERE/SPHERE_main.py
+++ b/easyeditor/models/SPHERE/SPHERE_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -88,8 +89,9 @@ def apply_SPHERE_to_model(
     deltas = execute_AlphaEdit(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, upd_m in deltas.items():
-            upd_matrix = upd_m.to(f"cuda:{hparams.device}")
+            upd_matrix = upd_m.to(device)
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
@@ -98,9 +100,9 @@ def apply_SPHERE_to_model(
             
             if hparams.cumulative_ratio > 0 and hparams.suppression_strength > 0:
                 upd_matrix_proj, P_soft, U = sparse_projection(w, upd_matrix, eta=hparams.cumulative_ratio, alpha=hparams.suppression_strength)
-                w[...] += upd_matrix_proj.float()
+                w[...] += upd_matrix_proj.to(device=w.device, dtype=w.dtype)
             else:
-                w[...] += upd_matrix.float()
+                w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -144,6 +146,7 @@ def execute_AlphaEdit(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -194,7 +197,7 @@ def execute_AlphaEdit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -247,13 +250,13 @@ def execute_AlphaEdit(
         repeat_factor = (layer_ks.size(1) // targets.size(1))
         targets = targets.repeat_interleave(repeat_factor, dim=1)
         resid = targets / (len(hparams.layers) - i)  # Distribute residual across layers
-        solve_device = f"cuda:{hparams.device}"
+        solve_device = device
         proj = P[i,:,:].to(solve_device).float()
         layer_ks = layer_ks.to(solve_device).float()
         resid = resid.to(solve_device).float()
         cache = cache_c[i,:,:].to(solve_device).float()
         upd_matrix = torch.linalg.solve(
-                proj @ (layer_ks @ layer_ks.T + cache) + hparams.L2*torch.eye(layer_ks.shape[0], dtype=proj.dtype,device=solve_device),
+                proj @ (layer_ks @ layer_ks.T + cache) + hparams.L2*torch.eye(layer_ks.shape[0], dtype=proj.dtype, device=solve_device),
                 proj @ layer_ks @ resid.T
         )
 
@@ -266,7 +269,8 @@ def execute_AlphaEdit(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            weights[weight_name][...] = weights[weight_name] + upd_matrix.float()
+            updated_weight = weights[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 upd_matrix.detach().cpu()
             )
@@ -285,7 +289,7 @@ def execute_AlphaEdit(
     # Restore state of original model
     with torch.no_grad():
         for k, v in weights.items():
-            v[...] = weights_copy[k]
+            copy_to_param(v, weights_copy[k])
     
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -327,9 +331,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    return (
-        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
-    )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/SPHERE/compute_z.py
+++ b/easyeditor/models/SPHERE/compute_z.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .SPHERE_hparams import SPHEREHyperParams
 
@@ -34,9 +35,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -52,10 +54,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
 
@@ -80,9 +82,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/alphaedit/AlphaEdit_main.py
+++ b/easyeditor/models/alphaedit/AlphaEdit_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -87,14 +88,15 @@ def apply_AlphaEdit_to_model(
     deltas = execute_AlphaEdit(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, upd_m in deltas.items():
-            upd_matrix = upd_m.to(f"cuda:{hparams.device}")
+            upd_matrix = upd_m.to(device)
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
-            w[...] += upd_matrix.float()
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -114,6 +116,7 @@ def execute_AlphaEdit(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -164,7 +167,7 @@ def execute_AlphaEdit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -217,13 +220,13 @@ def execute_AlphaEdit(
         repeat_factor = (layer_ks.size(1) // targets.size(1))
         targets = targets.repeat_interleave(repeat_factor, dim=1)
         resid = targets / (len(hparams.layers) - i)  # Distribute residual across layers
-        solve_device = f"cuda:{hparams.device}"
+        solve_device = device
         proj = P[i,:,:].to(solve_device).float()
         layer_ks = layer_ks.to(solve_device).float()
         resid = resid.to(solve_device).float()
         cache = cache_c[i,:,:].to(solve_device).float()
         upd_matrix = torch.linalg.solve(
-                proj @ (layer_ks @ layer_ks.T + cache) + hparams.L2*torch.eye(layer_ks.shape[0], dtype=proj.dtype,device=solve_device),
+                proj @ (layer_ks @ layer_ks.T + cache) + hparams.L2*torch.eye(layer_ks.shape[0], dtype=proj.dtype, device=solve_device),
                 proj @ layer_ks @ resid.T
         )
 
@@ -236,7 +239,8 @@ def execute_AlphaEdit(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            weights[weight_name][...] = weights[weight_name] + upd_matrix.float()
+            updated_weight = weights[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 upd_matrix.detach().cpu()
             )
@@ -255,7 +259,7 @@ def execute_AlphaEdit(
     # Restore state of original model
     with torch.no_grad():
         for k, v in weights.items():
-            v[...] = weights_copy[k]
+            copy_to_param(v, weights_copy[k])
     
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -297,9 +301,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    return (
-        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
-    )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/alphaedit/compute_z.py
+++ b/easyeditor/models/alphaedit/compute_z.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .AlphaEdit_hparams import AlphaEditHyperParams
 
@@ -34,9 +35,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -52,10 +54,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
 
@@ -80,9 +82,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/core/compute_z.py
+++ b/easyeditor/models/core/compute_z.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .core_hparams import COREHyperParams
 
@@ -44,9 +45,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -62,10 +64,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -89,9 +91,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/core/core_main.py
+++ b/easyeditor/models/core/core_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -46,15 +47,16 @@ def apply_core_to_model(
     deltas = execute_core(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, (key_mat, val_mat) in deltas.items():
-            key_mat, val_mat = key_mat.to(f"cuda:{hparams.device}"), val_mat.to(f"cuda:{hparams.device}")
+            key_mat, val_mat = key_mat.to(device), val_mat.to(device)
             upd_matrix = key_mat @ val_mat.T
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
-            w[...] += upd_matrix.float()
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -74,6 +76,7 @@ def execute_core(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -127,7 +130,7 @@ def execute_core(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -199,8 +202,8 @@ def execute_core(
 
         # Compute update in double precision
         layer_ks, targets = (
-            layer_ks.double(),
-            targets.double(),
+            layer_ks.double().to(device),
+            targets.double().to(device),
         )
 
         adj_k = torch.linalg.solve(
@@ -219,7 +222,8 @@ def execute_core(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
+            updated_weight = weights_copy[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 adj_k.detach().cpu(),  
                 resid.detach().cpu(),
@@ -235,7 +239,7 @@ def execute_core(
     # Restore state of original model
     with torch.no_grad():
         for k, v in weights.items():
-            v[...] = weights_copy[k]
+            copy_to_param(v, weights_copy[k])
 
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -277,9 +281,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    return (
-        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
-    )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/deepedit_api/deepedit_api_main.py
+++ b/easyeditor/models/deepedit_api/deepedit_api_main.py
@@ -7,6 +7,9 @@ from transformers import AutoTokenizer, AutoModel
 import string
 import logging    
 import os
+
+from ...util.device import normalize_device
+
 def apply_deepedit_api_to_model(
         datasets,
         hparams: DeepEditApiHyperParams,
@@ -35,8 +38,9 @@ def apply_deepedit_api_to_model(
         exist_prompt = f.read()
       
     ## read contriver, tokenizer
+    device = normalize_device(getattr(hparams, "device", None))
     contriver_dir = hparams.contriver_dir
-    contriever = AutoModel.from_pretrained(contriver_dir).cuda()
+    contriever = AutoModel.from_pretrained(contriver_dir).to(device)
     tokenizer_dir = hparams.contriver_dir
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_dir)
     
@@ -66,7 +70,7 @@ def apply_deepedit_api_to_model(
         all_embs = []
         for i in range(0, len(sents), BSZ):
             sent_batch = sents[i:i+BSZ]
-            inputs = tok(sent_batch, padding=True, truncation=True, return_tensors='pt').to("cuda")
+            inputs = tok(sent_batch, padding=True, truncation=True, return_tensors='pt').to(device)
             with torch.no_grad():
                 outputs = contriever(**inputs)
                 embeddings = mean_pooling(outputs[0], inputs['attention_mask'])
@@ -75,7 +79,7 @@ def apply_deepedit_api_to_model(
         return all_embs
     
     def retrieve_facts(query, fact_embs, contriever, tok, k=2):
-        inputs = tok([query], padding=True, truncation=True, return_tensors='pt').to("cuda")
+        inputs = tok([query], padding=True, truncation=True, return_tensors='pt').to(device)
         with torch.no_grad():
             outputs = contriever(**inputs)
             query_emb = mean_pooling(outputs[0], inputs['attention_mask']).cpu()

--- a/easyeditor/models/defer/defer_main.py
+++ b/easyeditor/models/defer/defer_main.py
@@ -6,6 +6,7 @@ from .DEFER import DEFER
 from .defer_hparams import DeferHyperParams
 from .utils import tokenize
 from ...util import nethook
+from ...util.device import normalize_device
 
 
 def apply_defer_to_model(
@@ -21,7 +22,7 @@ def apply_defer_to_model(
     request = requests[0]
     if copy:
         model = deepcopy(model)
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # print(model)
     if not isinstance(model, DEFER):
         editor = DEFER(model=model, config=hparams)

--- a/easyeditor/models/dinm/dinm_main.py
+++ b/easyeditor/models/dinm/dinm_main.py
@@ -7,6 +7,7 @@ from torch.nn import CrossEntropyLoss
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .dinm_hparams import DINMHyperParams
 from ...trainer import kl_loc_loss, masked_log_probs
@@ -67,7 +68,7 @@ def execute_dinm(
     Executes the FT update algorithm for the specified update at the specified layer
     Invariant: model at beginning of function == model at end of function
     """
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # model = model.to(device)
     # Update target and print info
     requests = deepcopy(requests)

--- a/easyeditor/models/dpo/dpo_main.py
+++ b/easyeditor/models/dpo/dpo_main.py
@@ -4,6 +4,7 @@ from peft import get_peft_model, AdaLoraConfig, TaskType, get_peft_model_state_d
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from ...util.device import normalize_device
 from .dpo_hparams import DPOHyperParams
 
 def apply_dpo_to_model(
@@ -24,7 +25,7 @@ def apply_dpo_to_model(
         # If you need to copy the model, handle it here
         pass  # Avoid deep copying to save memory
 
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     print(f"Using device: {device}")
 
     # Configure LoRA

--- a/easyeditor/models/eamet/compute_z.py
+++ b/easyeditor/models/eamet/compute_z.py
@@ -4,9 +4,9 @@ import numpy as np
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from rome import repr_tools
-from util import nethook
-from random_word import RandomWords
+from ..rome import repr_tools
+from ...util import nethook
+from ...util.device import normalize_device
 import random
 import copy
 import time
@@ -68,7 +68,8 @@ def compute_z(
     ### return_tensors="pt" gives [[xxx]].
     ##############################################################################
 
-    target_ids = tok(request["target_new"]["str"], return_tensors="pt").to("cuda")["input_ids"][0]
+    device = normalize_device(getattr(hparams, "device", None))
+    target_ids = tok(request["target_new"]["str"], return_tensors="pt").to(device)["input_ids"][0]
 
     print(f"DEBUG INFO:target_ids:{target_ids}")
     print(f"DEBUG INFO:tok('English'):{tok('English')}")
@@ -124,9 +125,9 @@ def compute_z(
         all_filled_prompts,
         return_tensors="pt",
         padding=True,
-    ).to("cuda")
+    ).to(device)
 
-    rewriting_targets = torch.tensor(-100, device="cuda").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -142,7 +143,7 @@ def compute_z(
     
     # Finalize rewrite and loss layers
     loss_layer = max(hparams.v_loss_layer, layer)
-    delta = torch.zeros((model.config.hidden_size, ), device="cuda", requires_grad=True)
+    delta = torch.zeros((model.config.hidden_size, ), device=device, requires_grad=True)
     target_init, kl_distr_init, target_constrain = None, None, None
 
     ### nonlocal helps to modify parameter from outer function
@@ -348,7 +349,6 @@ def noisy_trigger(
         num: int,
         tok: AutoTokenizer
 ) -> List[torch.Tensor]:
-    gen = RandomWords()
     trigers = tok([trigger], return_tensors="pt",
         padding=False)['input_ids'][0].tolist()
     noisy_list = []

--- a/easyeditor/models/eamet/eamet_main.py
+++ b/easyeditor/models/eamet/eamet_main.py
@@ -13,10 +13,11 @@ from tqdm import *
 from torch.utils.data import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from rome.layer_stats import layer_stats
-from util import nethook
-from util.generate import generate_fast, generate_standard
-from util.globals import *
+from ..rome.layer_stats import layer_stats
+from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
+from ...util.generate import generate_fast, generate_standard
+from ...util.globals import *
 
 from .compute_ks import compute_ks
 from .compute_z import compute_z, get_module_input_output_at_words, find_fact_lookup_idx
@@ -66,8 +67,9 @@ def apply_eamet_to_model(
                             duplicate_subjects=duplicate_subjects)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, (key_mat, val_mat) in deltas.items():
-            key_mat, val_mat = key_mat.to("cuda"), val_mat.to("cuda")
+            key_mat, val_mat = key_mat.to(device), val_mat.to(device)
             upd_matrix = key_mat @ val_mat.T
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
@@ -75,7 +77,7 @@ def apply_eamet_to_model(
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
 
-            w[...] += upd_matrix.float()
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -98,6 +100,7 @@ def execute_eamet(
     Invariant: model at beginning of function == model at end of function
     """
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     requests = deepcopy(requests)
 
@@ -168,8 +171,8 @@ def execute_eamet(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to("cuda"))
-                delta_list.append(torch.from_numpy(data["delta"]).to("cuda"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                delta_list.append(torch.from_numpy(data["delta"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -189,8 +192,8 @@ def execute_eamet(
                 layer_ks_norm=layer_ks_norm[re_id]
             )
 
-            z_list.append(opt_zs.to("cuda"))
-            delta_list.append(delta.to("cuda"))
+            z_list.append(opt_zs.to(device))
+            delta_list.append(delta.to(device))
             if cache_fname is not None:
                 try:
                     cache_fname.parent.mkdir(exist_ok=True, parents=True)
@@ -253,28 +256,18 @@ def execute_eamet(
             else hparams.mom2_n_samples // 10,
             hparams.mom2_dtype,
             force_recompute=force_recompute,
+            hparams=hparams,
         )
 
         # Compute update in double precision
-        if torch.cuda.device_count() == 1:
-            layer_ks, targets = (
-                layer_ks.double(),
-                targets.double(),
-            )
-        else:
-            layer_ks, targets = (
-                layer_ks.double().to("cuda:1"),
-                targets.double().to("cuda:1"),
-            )
+        layer_ks, targets = (
+            layer_ks.double().to(device),
+            targets.double().to(device),
+        )
 
         cov_mat = hparams.mom2_update_weight[i] * cov.double() + (layer_ks @ layer_ks.T)
         start_time = time.time()
-        if torch.cuda.device_count() == 1:
-            adj_k = torch.inverse(cov_mat.to("cpu")).to("cuda") \
-                @ layer_ks
-        else:
-            adj_k = torch.inverse(cov_mat.to("cuda:1")).to("cuda:1") \
-                @ layer_ks
+        adj_k = torch.inverse(cov_mat.to(device)) @ layer_ks
         print(f"computing inverse takes:{time.time()-start_time}")
         norm_of_inv= torch.norm(torch.inverse(cov_mat.to("cpu")))
         print(f"norm of inv:{norm_of_inv}")
@@ -298,11 +291,8 @@ def execute_eamet(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            if torch.cuda.device_count() == 1:
-                weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
-            else:
-                weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float().to("cuda:0")
-            #weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
+            updated_weight = weights_copy[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 adj_k.detach().cpu(),
                 resid.detach().cpu(),
@@ -318,7 +308,7 @@ def execute_eamet(
     # Restore state of original model
     with torch.no_grad():
         for k, _ in weights.items():
-            nethook.get_parameter(model, k)[...] = weights_copy[k]
+            copy_to_param(nethook.get_parameter(model, k), weights_copy[k])
 
     # with torch.no_grad():
     #     for k, v in weights.items():
@@ -338,6 +328,7 @@ def get_cov(
     mom2_dtype: str,
     inv: bool = False,
     force_recompute: bool = False,
+    hparams: Optional[EAMETHyperParams] = None,
 ) -> torch.Tensor:
     """
     Retrieves covariance statistics, then computes the algebraic inverse.
@@ -360,19 +351,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    if torch.cuda.device_count() == 1:  
-        return (
-            torch.inverse(COV_CACHE[key].to("cuda")) if inv else COV_CACHE[key].to("cuda")
-        )
-    else:
-        try:
-            return (
-                torch.inverse(COV_CACHE[key].to("cuda:1")) if inv else COV_CACHE[key].to("cuda:1")
-            )
-        except:
-            return (
-                torch.inverse(COV_CACHE[key].to("cuda:0")) if inv else COV_CACHE[key].to("cuda:0")
-            )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/eamet/hparams.py
+++ b/easyeditor/models/eamet/hparams.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Literal
 
-from util.hparams import HyperParams
+from ...util.hparams import HyperParams
 
 
 @dataclass

--- a/easyeditor/models/emmet/compute_z.py
+++ b/easyeditor/models/emmet/compute_z.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .emmet_hparams import EMMETHyperParams
 
@@ -34,9 +35,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -52,10 +54,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -79,9 +81,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/emmet/emmet_main.py
+++ b/easyeditor/models/emmet/emmet_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -46,15 +47,16 @@ def apply_emmet_to_model(
     deltas = execute_emmet(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, (key_mat, val_mat) in deltas.items():
-            key_mat, val_mat = key_mat.to(f"cuda:{hparams.device}"), val_mat.to(f"cuda:{hparams.device}")
+            key_mat, val_mat = key_mat.to(device), val_mat.to(device)
             upd_matrix = key_mat @ val_mat.T
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
-            w[...] += upd_matrix.float()
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -77,6 +79,7 @@ def execute_emmet(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -130,7 +133,7 @@ def execute_emmet(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -202,9 +205,9 @@ def execute_emmet(
 
         # Compute update in double precision
         layer_ks, targets, cov = (
-            layer_ks.double(),
-            targets.double(),
-            cov.double()
+            layer_ks.double().to(device),
+            targets.double().to(device),
+            cov.double().to(device)
         )
 
         #add optimization hyper-parameters
@@ -239,7 +242,8 @@ def execute_emmet(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
+            updated_weight = weights_copy[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 adj_k.detach().cpu(),
                 resid.detach().cpu(),
@@ -255,7 +259,7 @@ def execute_emmet(
     # Restore state of original model
     with torch.no_grad():
         for k, v in weights.items():
-            v[...] = weights_copy[k]
+            copy_to_param(v, weights_copy[k])
 
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -297,9 +301,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    return (
-        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
-    )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/ft/ft_main.py
+++ b/easyeditor/models/ft/ft_main.py
@@ -7,6 +7,7 @@ from torch.nn import CrossEntropyLoss
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .ft_hparams import FTHyperParams
 
@@ -57,7 +58,7 @@ def execute_ft(
     Executes the FT update algorithm for the specified update at the specified layer
     Invariant: model at beginning of function == model at end of function
     """
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # model = model.to(device)
     # Update target and print info
     requests = deepcopy(requests)

--- a/easyeditor/models/ft_uns/ft_uns_main.py
+++ b/easyeditor/models/ft_uns/ft_uns_main.py
@@ -7,6 +7,7 @@ from torch.nn import CrossEntropyLoss
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util import nethook
+from ...util.device import normalize_device
 from .ft_uns_hparams import FT_uns_HyperParams
 
 
@@ -56,7 +57,7 @@ def execute_ft_uns(
     Executes the FT update algorithm for the specified update at the specified layer
     Invariant: model at beginning of function == model at end of function
     """
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     batch_data = deepcopy(batch_data)
     texts = [data["question"] for data in batch_data]
     targets = [data["answer"] for data in batch_data]

--- a/easyeditor/models/grace/grace_main.py
+++ b/easyeditor/models/grace/grace_main.py
@@ -6,6 +6,7 @@ from .GRACE import GRACE, GRACEMultimodal
 from .grace_hparams import GraceHyperParams
 from .utils import tokenize, multimodal_tokenize
 from ...util import nethook
+from ...util.device import normalize_device
 
 
 def apply_grace_to_model(
@@ -21,7 +22,7 @@ def apply_grace_to_model(
     request = requests[0]
     if copy:
         model = deepcopy(model)
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     editor = GRACE(model=model, config=hparams, device=device)
     tokens = tokenize(request, tokenizer=tok, device=device)
     editor.edit(config=hparams, tokens=tokens,edit_id=request['target_new'])
@@ -42,7 +43,7 @@ def apply_grace_to_multimodal_model(
         keep_original_weight=False,
         **kwargs: Any,
 ) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     if copy:
         model = deepcopy(model)
         model.to(device)

--- a/easyeditor/models/ike/ike_main.py
+++ b/easyeditor/models/ike/ike_main.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Tuple
 import torch
 from torch import tensor
 
+from ...util.device import normalize_device
+
 
 def apply_ike_to_model(
     model: AutoModelForCausalLM,
@@ -27,7 +29,7 @@ def apply_ike_to_model(
     if type(request) is list:
         request = request[0]
 
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
 
     new_fact = request['prompt'] + ' ' + request['target_new']
     if hparams.use_icl_examples is True:
@@ -72,7 +74,7 @@ def apply_ike_to_multimodal_model(
 ) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
     
     assert train_ds is not None
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     sentence_model = SentenceTransformer(hparams.sentence_model_name).to(device)
 
     safe_model_name = hparams.sentence_model_name.rsplit('/', 1)[-1]

--- a/easyeditor/models/kn/kn_main.py
+++ b/easyeditor/models/kn/kn_main.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from ...util.device import normalize_device
 from .kn_hparams import KNHyperParams
 from .knowledge_neurons.knowledge_neurons import KnowledgeNeurons, model_type
 
@@ -25,7 +26,7 @@ def apply_kn_to_model(
         model,
         tok,
         model_type=model_type(hparams.model_name),
-        device=f"cuda:{hparams.device}",
+        device=str(normalize_device(getattr(hparams, "device", None))),
     )
     request_rewrite = deepcopy(request)
     text = [request_rewrite["prompt"]]

--- a/easyeditor/models/lora/lora_main.py
+++ b/easyeditor/models/lora/lora_main.py
@@ -4,6 +4,7 @@ from peft import get_peft_model, AdaLoraConfig, TaskType, get_peft_model_state_d
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoProcessor
 
+from ...util.device import normalize_device
 from .lora_hparams import LoRAHyperParams
 from .lora_multimodal_hparams import LoRAMultimodalHyperParams
 
@@ -80,7 +81,7 @@ def execute_lora(
             f"Executing LoRA algo for: "
             f"[{request['prompt']}] -> [{request['target_new']}]"
         )
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # Define inputs
     texts = [r["prompt"] for r in requests]
     targets = [r["target_new"] for r in requests]
@@ -191,7 +192,7 @@ def apply_lora_to_multimodal_model(
     :return: (1) the updated model, (2) the weights that changed
     """
     weights_copy = {}
-    device = f'cuda:{hparams.device}'
+    device = normalize_device(getattr(hparams, "device", None))
     if copy:
         model = deepcopy(model)
         model.to(device)
@@ -255,7 +256,7 @@ def execute_multimodal_lora(
             f"Executing LoRA algo for: "
             f"[{request['prompt']}] -> [{request['target']}]"
         )
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # Define inputs
     prompts = [r["prompt"] for r in requests]
     labels = [r["target"] for r in requests]

--- a/easyeditor/models/lora_uns/lora_uns_main.py
+++ b/easyeditor/models/lora_uns/lora_uns_main.py
@@ -4,6 +4,7 @@ from peft import get_peft_model, AdaLoraConfig, TaskType, get_peft_model_state_d
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoProcessor
 
+from ...util.device import normalize_device
 from .lora_uns_hparams import LoRA_uns_HyperParams
 
 def apply_lora_uns_to_model(
@@ -72,7 +73,7 @@ def execute_lora_uns(
         peft_model.print_trainable_parameters()
     batch_data = deepcopy(batch_data)
     
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     # Define inputs
     texts = [data["question"] for data in batch_data]
     targets = [data["answer"] for data in batch_data]

--- a/easyeditor/models/malmen/malmen_main.py
+++ b/easyeditor/models/malmen/malmen_main.py
@@ -8,6 +8,7 @@ from collections import deque
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 
 from ...trainer import MALMEN
 from .malmen_hparams import MALMENHyperParams
@@ -26,12 +27,13 @@ class MalmenRewriteExecutor:
 
         # Load the trained MEND model
         self.alg = MALMEN(self.model, params, lambda: deepcopy(self.model))
-        d = torch.load(params.archive, map_location=f'cuda:{params.device}')
+        device = normalize_device(getattr(params, "device", None))
+        d = torch.load(params.archive, map_location=device)
         self.alg.load_state_dict(d["model"])
         if params.model_parallel:
             self.alg.net.to(deque(self.alg.model.parameters(), maxlen=1)[0].device)
         else:
-            self.alg.to(torch.device(f'cuda:{params.device}'))
+            self.alg.to(device)
 
 
     def reset_model(self):
@@ -82,12 +84,9 @@ class MalmenRewriteExecutor:
             ]
 
             # Tokenize
-            sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(
-                f"cuda:{hparams.device}"
-            )
-            target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(
-                f"cuda:{hparams.device}"
-            )
+            device = normalize_device(getattr(hparams, "device", None))
+            sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(device)
+            target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(device)
 
             # Define labels
             label_tok = deepcopy(sent_tok["input_ids"])
@@ -117,4 +116,4 @@ class MalmenRewriteExecutor:
         self.alg.edit_model(param_shifts, False)
 
         return self.alg.model, weights_copy
- 
+

--- a/easyeditor/models/melo/melo_main.py
+++ b/easyeditor/models/melo/melo_main.py
@@ -6,6 +6,7 @@ from .melo_hparams import MELOHyperParams
 from .util import get_tokenizer
 from .melo import LORA
 from ...util import nethook
+from ...util.device import normalize_device
 
 
 def apply_melo_to_model(
@@ -22,7 +23,7 @@ def apply_melo_to_model(
     if keep_original_weight:
         model=deepcopy(model)
     weights_copy = {}
-    device = torch.device(f'cuda:{hparams.device}')
+    device = normalize_device(getattr(hparams, "device", None))
     tokenizer = get_tokenizer(hparams)
     if not isinstance(model, LORA):
         editor = LORA(model, hparams,tokenizer)

--- a/easyeditor/models/memit/compute_z.py
+++ b/easyeditor/models/memit/compute_z.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .memit_hparams import MEMITHyperParams
 
@@ -34,9 +35,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -52,10 +54,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -79,9 +81,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/memit/memit_main.py
+++ b/easyeditor/models/memit/memit_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -46,15 +47,16 @@ def apply_memit_to_model(
     deltas = execute_memit(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
+        device = normalize_device(getattr(hparams, "device", None))
         for w_name, (key_mat, val_mat) in deltas.items():
-            key_mat, val_mat = key_mat.to(f"cuda:{hparams.device}"), val_mat.to(f"cuda:{hparams.device}")
+            key_mat, val_mat = key_mat.to(device), val_mat.to(device)
             upd_matrix = key_mat @ val_mat.T
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
-            w[...] += upd_matrix.float()
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype)
 
     print(f"New weights successfully inserted into {list(deltas.keys())}")
 
@@ -74,6 +76,7 @@ def execute_memit(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -127,7 +130,7 @@ def execute_memit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                z_list.append(torch.from_numpy(data["v_star"]).to(device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -199,8 +202,8 @@ def execute_memit(
 
         # Compute update in double precision
         layer_ks, targets = (
-            layer_ks.double(),
-            targets.double(),
+            layer_ks.double().to(device),
+            targets.double().to(device),
         )
 
         adj_k = torch.linalg.solve(
@@ -219,7 +222,8 @@ def execute_memit(
 
         # Update model weights and record desired changes in `delta` variable
         with torch.no_grad():
-            weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
+            updated_weight = weights_copy[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+            copy_to_param(weights[weight_name], updated_weight)
             deltas[weight_name] = (
                 adj_k.detach().cpu(),
                 resid.detach().cpu(),
@@ -235,7 +239,7 @@ def execute_memit(
     # Restore state of original model
     with torch.no_grad():
         for k, v in weights.items():
-            v[...] = weights_copy[k]
+            copy_to_param(v, weights_copy[k])
 
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -277,9 +281,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    return (
-        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
-    )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 
 
 def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:

--- a/easyeditor/models/mend/mend_main.py
+++ b/easyeditor/models/mend/mend_main.py
@@ -9,6 +9,7 @@ from collections import deque
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 from ...trainer import MEND
 from .mend_hparams import MENDHyperParams
 from .mend_multimodal_hparams import MENDMultimodalHparams
@@ -42,9 +43,6 @@ class MendRewriteExecutor:
         )
         # if params.model_parallel:
         self.alg.mend.to(deque(self.alg.model.parameters(), maxlen=1)[0].device)
-        # else:
-        #     self.alg.to(torch.device(f'cuda:{params.device}'))
-
         # Disable unneeded gradients
         for n, p in self.model.named_parameters():
             if n not in params.inner_params:
@@ -95,12 +93,9 @@ class MendRewriteExecutor:
         ]
 
         # Tokenize
-        sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(
-            f"cuda:{hparams.device}"
-        )
-        target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(
-            f"cuda:{hparams.device}"
-        )
+        device = normalize_device(getattr(hparams, "device", None))
+        sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(device)
+        target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(device)
 
         # Define labels
         label_tok = deepcopy(sent_tok["input_ids"])
@@ -146,8 +141,8 @@ class MendRewriteExecutor:
                         p.copy_(edited_model.model.state_dict()[n])
 
         return model, weights_copy
-    
-    
+
+
 class MendMultimodalRewriteExecutor(MendRewriteExecutor):
     def __init__(self):
         super().__init__()
@@ -169,12 +164,13 @@ class MendMultimodalRewriteExecutor(MendRewriteExecutor):
 
         # Load the trained MEND model
         self.alg = MEND(self.model, params, lambda: deepcopy(self.model))
-        d = torch.load(params.archive)
+        device = normalize_device(getattr(params, "device", None))
+        d = torch.load(params.archive, map_location=device)
 
         self.alg.load_state_dict(
             {k.replace("gtn.", "mend."): v for k, v in d["model"].items()}
         )
-        self.alg.to(torch.device(f'cuda:{params.device}'))
+        self.alg.to(device)
 
         # Disable unneeded gradients
         for n, p in self.model.named_parameters():
@@ -261,7 +257,7 @@ class MendMultimodalRewriteExecutor(MendRewriteExecutor):
 class MendPerRewriteExecutor(MendRewriteExecutor):
     def __init__(self):
         super().__init__()
-        
+
     def apply_to_model(
         self,
         request,
@@ -274,7 +270,7 @@ class MendPerRewriteExecutor(MendRewriteExecutor):
         keep_original_weight=False,
         **kwargs
     ):
-        
+
         if not self.is_init:
             self.init_model(model, tok, hparams)
 
@@ -283,6 +279,6 @@ class MendPerRewriteExecutor(MendRewriteExecutor):
 
         self.alg.eval()
         edited_model, model_info = self.alg.edit(request["cond"], personality=True, return_factors=True)
-        
+
         return edited_model, weights_copy
-        
+

--- a/easyeditor/models/pmet/compute_zs.py
+++ b/easyeditor/models/pmet/compute_zs.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .pmet_hparams import PMETHyperParams
 
@@ -39,9 +40,10 @@ def compute_zs(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
 
     # Compile list of rewriting and KL x/y pairs
@@ -56,10 +58,10 @@ def compute_zs(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to("cuda")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device="cuda").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -83,11 +85,11 @@ def compute_zs(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
-        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
-        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, "hidden_size"):
-        delta_attn = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
-        delta_mlp = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
+        delta_attn = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta_mlp = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init_attn, target_init_mlp, kl_distr_init = None, None, None
@@ -248,9 +250,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok(request["target_new"], return_tensors="pt").to("cuda")[
+    target_ids = tok(request["target_new"], return_tensors="pt").to(device)[
         "input_ids"
     ][0]
 
@@ -266,10 +269,10 @@ def compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to("cuda")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device="cuda").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -293,9 +296,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, "hidden_size"):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None

--- a/easyeditor/models/pmet/pmet_main.py
+++ b/easyeditor/models/pmet/pmet_main.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
+from ...util.device import copy_to_param, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -49,14 +50,13 @@ def apply_pmet_to_model(
 
     with torch.no_grad():
         for w_name, upd_matrix in deltas.items(): #w_name, adj_k, resid
-            upd_matrix = upd_matrix.to("cuda")
             w = nethook.get_parameter(model, w_name)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
                 weights_copy[w_name] = w.detach().clone()
 
-            w[...] += upd_matrix.float() #w[...]高级索引，表示对w中每个元素进行操作
+            w[...] += upd_matrix.to(device=w.device, dtype=w.dtype) #w[...]高级索引，表示对w中每个元素进行操作
 
     print(f"\nNew weights successfully inserted into {list(deltas.keys())}")
 
@@ -76,6 +76,7 @@ def execute_pmet(
     """
 
     deltas = {}
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Update target and print info
     requests = deepcopy(requests)
@@ -133,7 +134,7 @@ def execute_pmet(
             ):
                 try:
                     data = np.load(cache_fname)
-                    z_list[rewrite_module_name].append(torch.from_numpy(data["v_star"]).to("cuda"))
+                    z_list[rewrite_module_name].append(torch.from_numpy(data["v_star"]).to(device))
                     data_loaded = True
                 except Exception as e:
                     print(f"Error reading cache file due to {e}. Recomputing...")
@@ -232,16 +233,10 @@ def execute_pmet(
                 fact_token_strategy=hparams.fact_token,
             )[1].T
             targets = z_list[rewrite_module_name]  - cur_zs #z_i - h_i^L
-            try:
-                layer_ks, targets = (
-                    layers_ks[rewrite_module_name].T.double(),
-                    targets.double()
-                )
-            except:
-                layer_ks, targets = (
-                    layers_ks[rewrite_module_name].T.double().to("cuda:1"),
-                    targets.double().to("cuda:1")
-                )
+            layer_ks, targets = (
+                layers_ks[rewrite_module_name].T.double().to(device),
+                targets.double().to(device)
+            )
             # Load covariance matrix
             force_recompute = False
             # force_recompute = layer != hparams.layers[0]
@@ -270,7 +265,8 @@ def execute_pmet(
 
             # Update model weights and record desired changes in `delta` variable
             with torch.no_grad():
-                weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float().to("cuda:0")
+                updated_weight = weights_copy[weight_name].to(device=upd_matrix.device, dtype=upd_matrix.dtype) + upd_matrix
+                copy_to_param(weights[weight_name], updated_weight)
                 deltas[weight_name] = upd_matrix
 
             # Clear GPU memory
@@ -283,7 +279,7 @@ def execute_pmet(
     # Restore state of original model
     with torch.no_grad():
         for k, _ in weights.items():
-            nethook.get_parameter(model, k)[...] = weights_copy[k]
+            copy_to_param(nethook.get_parameter(model, k), weights_copy[k])
 
     print(f"Deltas successfully computed for {list(weights.keys())}")
 
@@ -340,14 +336,8 @@ def get_cov(
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
 
-    try:
-        return (
-            torch.inverse(COV_CACHE[key].to("cuda:0")) if inv else COV_CACHE[key].to("cuda:0")
-        )
-    except:
-        return (
-            torch.inverse(COV_CACHE[key].to("cuda:1")) if inv else COV_CACHE[key].to("cuda:1")
-        )
+    cov = COV_CACHE[key].to(normalize_device(getattr(hparams, "device", None)))
+    return torch.inverse(cov) if inv else cov
 def get_context_templates(model, tok):
     global CONTEXT_TEMPLATES_CACHE
 

--- a/easyeditor/models/qlora/qlora_main.py
+++ b/easyeditor/models/qlora/qlora_main.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Tuple
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import get_peft_model, LoraConfig, prepare_model_for_kbit_training
+from ...util.device import normalize_device
 from .qlora_hparams import QLoRAHyperParams
 
 def apply_qlora_to_model(
@@ -47,7 +48,7 @@ def execute_qlora(
     model.enable_input_require_grads()
 
     # hparams.device = 1
-    device = torch.device(f"cuda:{hparams.device}")
+    device = normalize_device(getattr(hparams, "device", None))
     model.to(device)
 
     # Prepare data

--- a/easyeditor/models/r_rome/compute_u.py
+++ b/easyeditor/models/r_rome/compute_u.py
@@ -6,6 +6,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
+from ...util.device import normalize_device
 from ...util.globals import *
 
 from .layer_stats import layer_stats
@@ -51,7 +52,7 @@ def get_inv_cov(
             hparams=hparams,
         )
         inv_mom2_cache[key] = torch.inverse(
-            stat.mom2.moment().to(f"cuda:{hparams.device}")
+            stat.mom2.moment().to(normalize_device(getattr(hparams, "device", None)))
         ).float()  # Cast back to float32
 
     return inv_mom2_cache[key]

--- a/easyeditor/models/r_rome/compute_v.py
+++ b/easyeditor/models/r_rome/compute_v.py
@@ -7,6 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .r_rome_hparams import R_ROMEHyperParams
 
@@ -26,11 +27,10 @@ def compute_v(
     """
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok(request["target_new"], return_tensors="pt").to(
-        f"cuda:{hparams.device}"
-    )["input_ids"][0]
+    target_ids = tok(request["target_new"], return_tensors="pt").to(device)["input_ids"][0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -48,10 +48,10 @@ def compute_v(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -85,13 +85,13 @@ def compute_v(
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
         delta = torch.zeros(
-            (model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}"
+            (model.config.n_embd,), requires_grad=True, device=device
         )
     else:
         delta = torch.zeros(
             (model.config.hidden_size,),
             requires_grad=True,
-            device=f"cuda:{hparams.device}",
+            device=device,
         )
     target_init, kl_distr_init = None, None
 

--- a/easyeditor/models/r_rome/layer_stats.py
+++ b/easyeditor/models/r_rome/layer_stats.py
@@ -7,6 +7,7 @@ from tqdm.auto import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 from ...util.nethook import Trace, set_requires_grad
 from ...util.runningstats import CombinedStat, Mean, NormMean, SecondMoment, tally
 
@@ -46,8 +47,9 @@ def main():
     aa("--download", default=1, type=int, choices=[0, 1])
     args = parser.parse_args()
 
+    device = normalize_device(None)
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-    model = AutoModelForCausalLM.from_pretrained(args.model_name).eval().cuda()
+    model = AutoModelForCausalLM.from_pretrained(args.model_name).eval().to(device)
     set_requires_grad(False, model)
 
     for layer_num in args.layers:
@@ -182,7 +184,7 @@ def layer_stats(
     with torch.no_grad():
         for batch_group in progress(loader, total=batch_count):
             for batch in batch_group:
-                batch = dict_to_(batch, f"cuda:{hparams.device}")
+                batch = dict_to_(batch, normalize_device(getattr(hparams, "device", None)))
                 with Trace(
                     model, layer_name, retain_input=True, retain_output=False, stop=True
                 ) as tr:

--- a/easyeditor/models/rome/compute_u.py
+++ b/easyeditor/models/rome/compute_u.py
@@ -6,6 +6,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
+from ...util.device import normalize_device
 from ...util.globals import *
 
 from .layer_stats import layer_stats
@@ -51,7 +52,7 @@ def get_inv_cov(
             hparams=hparams
         )
         inv_mom2_cache[key] = torch.inverse(
-            stat.mom2.moment().to(f"cuda:{hparams.device}")
+            stat.mom2.moment().to(normalize_device(getattr(hparams, "device", None)))
         ).float()  # Cast back to float32
 
     return inv_mom2_cache[key]

--- a/easyeditor/models/rome/compute_v.py
+++ b/easyeditor/models/rome/compute_v.py
@@ -7,6 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .rome_hparams import ROMEHyperParams
 
@@ -26,9 +27,10 @@ def compute_v(
     """
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     # if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
     #     target_ids = target_ids[1:]
@@ -43,10 +45,10 @@ def compute_v(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -74,9 +76,9 @@ def compute_v(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     else:
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     target_init, kl_distr_init = None, None
 
     # Inserts new "delta" variable at the appropriate part of the computation

--- a/easyeditor/models/rome/layer_stats.py
+++ b/easyeditor/models/rome/layer_stats.py
@@ -7,6 +7,7 @@ from tqdm.auto import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 from ...util.nethook import Trace, set_requires_grad
 from ...util.runningstats import CombinedStat, Mean, NormMean, SecondMoment, tally
 
@@ -46,8 +47,9 @@ def main():
     aa("--download", default=1, type=int, choices=[0, 1])
     args = parser.parse_args()
 
+    device = normalize_device(None)
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-    model = AutoModelForCausalLM.from_pretrained(args.model_name).eval().cuda()
+    model = AutoModelForCausalLM.from_pretrained(args.model_name).eval().to(device)
     set_requires_grad(False, model)
 
     for layer_num in args.layers:
@@ -186,7 +188,7 @@ def layer_stats(
     with torch.no_grad():
         for batch_group in progress(loader, total=batch_count):
             for batch in batch_group:
-                batch = dict_to_(batch, f"cuda:{hparams.device}")
+                batch = dict_to_(batch, normalize_device(getattr(hparams, "device", None)))
                 with Trace(
                     model, layer_name, retain_input=True, retain_output=False, stop=True
                 ) as tr:

--- a/easyeditor/models/serac/serac_main.py
+++ b/easyeditor/models/serac/serac_main.py
@@ -7,6 +7,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 
 from ...trainer import SERAC, SERAC_MULTI
 from .serac_hparams import SERACHparams
@@ -32,9 +33,9 @@ class SeracRewriteExecutor:
         self.alg = SERAC(self.model, deepcopy(params), lambda: deepcopy(self.model))
         d = torch.load(params.archive, map_location='cpu')
         self.alg.load_state_dict(d["model"], False)
-        # self.alg.to(torch.device(f'cuda:{params.device}'))
-        self.alg.replacement.to(torch.device(f'cuda:{params.device}'))
-        self.alg.classifier.to(torch.device(f'cuda:{params.device}'))
+        device = normalize_device(getattr(params, "device", None))
+        self.alg.replacement.to(device)
+        self.alg.classifier.to(device)
 
         self.is_init = True
 
@@ -82,13 +83,12 @@ class SeracRewriteExecutor:
         ]
         #
         # # Tokenize
-        sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(
-            f"cuda:{hparams.device}"
-        )
+        device = normalize_device(getattr(hparams, "device", None))
+        sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(device)
         label_tok = self.tokenizer([request["target_new"] for request in requests],
                                     padding=True,
                                     return_tensors="pt"
-                                    ).to(f"cuda:{hparams.device}")
+                                    ).to(device)
         #
         # # label_tok = deepcopy(sent_tok["input_ids"])
         # # for i in range(label_tok.size(0)):
@@ -133,16 +133,6 @@ class SeracRewriteExecutor:
         # ]
         #
         # targets = [target for targets_ in targets for target in targets_]
-
-        # label_tok = self.tokenizer(targets,
-        #                             padding=True,
-        #                             return_tensors="pt"
-        #                             ).to(f"cuda:{hparams.device}")
-
-        # Tokenize
-        # sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(
-        #     f"cuda:{hparams.device}"
-        # )
 
         # label_tok = deepcopy(sent_tok["input_ids"])
         # for i in range(label_tok.size(0)):
@@ -219,9 +209,10 @@ class SeracMultimodalRewriteExecutor(SeracRewriteExecutor):
         self.alg = SERAC_MULTI(self.model, params, lambda: deepcopy(self.model))
         d = torch.load(params.archive, map_location='cpu')
         self.alg.load_state_dict(d["model"], False)
-        self.alg.to(torch.device(f'cuda:{params.device}'))
-        self.alg.replacement.to(torch.device(f'cuda:{params.device}'))
-        self.alg.classifier.to(torch.device(f'cuda:{params.device}'))
+        device = normalize_device(getattr(params, "device", None))
+        self.alg.to(device)
+        self.alg.replacement.to(device)
+        self.alg.classifier.to(device)
 
         self.is_init = True
 

--- a/easyeditor/models/simie/simie.py
+++ b/easyeditor/models/simie/simie.py
@@ -7,6 +7,7 @@ from .utils import (
     TracerDict,
 )
 import torch
+from ...util.device import normalize_device
 
 class SimIE:
     def __init__(self, lamHyper: float, init: bool, solver: str="LU"):
@@ -15,7 +16,7 @@ class SimIE:
         self.solver = solver
 
     def initialization(self, model_name, init_weights, device, fast=True):
-        self.device = f"cuda:{device}"
+        self.device = str(normalize_device(device))
         self.init_weights_copy = {n: p.clone().cpu() for n, p in init_weights.items()}
         self.weights_copy = {n: p.clone().cpu() for n, p in init_weights.items()}
         if "llama" in model_name.lower() or "gpt-j-6b" in model_name.lower() or "mistral" in model_name.lower():
@@ -109,7 +110,7 @@ class SimIE:
                 attention_mask=sent_tok["attention_mask"],
                 labels=target_tok['input_ids'],
             )
-            
+
             batchs.append(edit_inner)
 
         # cache keys
@@ -124,18 +125,18 @@ class SimIE:
                     _ = model(input_ids=t['input_ids'], attention_mask=t['attention_mask'])
 
                 for module_idx, module_name in enumerate(self.config["inner_params"]):
-                    keys = tr[module_name].keys.to(torch.float32).to(self.device).clone() 
+                    keys = tr[module_name].keys.to(torch.float32).to(self.device).clone()
                     keys_cache.setdefault(module_name+".weight", {}).update({idx: {'keys': keys}})
         return keys_cache
-    
+
     def update(self, edited_model, keys_cache):
 
         for module_name, batch_data in keys_cache.items():
             keys_list = []
-            
+
             for idx, data in batch_data.items():
                 keys_list.append(data['keys'])
-            
+
             # combine keys
             key_all = torch.cat(keys_list, dim=0)
             if self.fast:
@@ -160,7 +161,7 @@ class SimIE:
             # del key_all, weights_copy_gpu, mat, delta_par
 
         return edited_model
-    
+
     def ideal_editor(self, edited_model, keys_cache, run=None):
         if not hasattr(self, 'KKT'):
             if self.transpose:
@@ -171,7 +172,7 @@ class SimIE:
                 self.BKT = {n: torch.zeros(p.shape[0],p.shape[1]).to(dtype=p.dtype) for n, p in self.init_weights_copy.items()}
 
         for module_name, batch_data in keys_cache.items():
-            keys_list = []   
+            keys_list = []
             for idx, data in batch_data.items():
                 keys_list.append(data['keys'])
             # combine keys
@@ -182,7 +183,7 @@ class SimIE:
                 self.BKT[module_name] += (parameter_diff.T @ key_all.T @ key_all).cpu()
             else:
                 self.BKT[module_name] += (parameter_diff @ key_all.T @ key_all).cpu()
-        
+
         if run is not None:
             ideal = {
                 "KKT": self.KKT,
@@ -191,4 +192,4 @@ class SimIE:
             torch.save(ideal, f"outputs/{run.config.data_type}_{run.config.model_name}_{run.config.editing_method}_ideal_editor.pth")
 
 
-    
+

--- a/easyeditor/models/ultraedit/ULTRAEDIT.py
+++ b/easyeditor/models/ultraedit/ULTRAEDIT.py
@@ -23,6 +23,7 @@ from ...trainer.algs.malmen.util import (
 )
 
 from ...trainer.algs.malmen.nets import RunningMeanStd
+from ...util.device import normalize_device
 from ...trainer.utils import (
     EarlyStopper,
     RunningStatAverager,
@@ -70,8 +71,7 @@ class ULTRAEDIT(EditableModel):
         elif 'mistral' in config.model_name.lower():
             self.shift = True
 
-        if not str(self.config.device).startswith('cuda'):
-            self.config.device = f'cuda:{self.config.device}'
+        self.config.device = str(normalize_device(getattr(self.config, "device", None)))
         
         if config.half:
             self.model.half()

--- a/easyeditor/models/ultraedit/ultraedit_main.py
+++ b/easyeditor/models/ultraedit/ultraedit_main.py
@@ -8,6 +8,7 @@ from collections import deque
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ...util.globals import *
+from ...util.device import normalize_device
 
 from .ULTRAEDIT import ULTRAEDIT
 from .ultraedit_hparams import UltraEditHyperParams
@@ -26,7 +27,7 @@ class UltraEditRewriteExecutor:
         if params.model_parallel:
             self.alg.lifelong_normalizer.to(deque(self.alg.model.parameters(), maxlen=1)[0].device)
         else:
-            self.alg.to(torch.device(f'cuda:{params.device}'))
+            self.alg.to(normalize_device(getattr(params, "device", None)))
 
 
     def reset_model(self):
@@ -77,12 +78,9 @@ class UltraEditRewriteExecutor:
             ]
 
             # Tokenize
-            sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(
-                f"cuda:{hparams.device}"
-            )
-            target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(
-                f"cuda:{hparams.device}"
-            )
+            device = normalize_device(getattr(hparams, "device", None))
+            sent_tok = self.tokenizer(sentences, padding=True, return_tensors="pt").to(device)
+            target_tok = self.tokenizer(targets, padding=True, return_tensors="pt").to(device)
 
             # Define labels
             label_tok = deepcopy(sent_tok["input_ids"])
@@ -106,7 +104,7 @@ class UltraEditRewriteExecutor:
             batchs,
             key=lambda x: torch.sum(x['attention_mask']).item(),
             reverse=True
-        )        
+        )
         module_kv_map = self.alg.cache(batchs)
         param_shifts = self.alg.predict_param_shifts(module_kv_map)
         with torch.no_grad():
@@ -117,4 +115,4 @@ class UltraEditRewriteExecutor:
         self.alg.edit_model(param_shifts, False)
 
         return self.alg.model, weights_copy
- 
+

--- a/easyeditor/models/unke/compute_z.py
+++ b/easyeditor/models/unke/compute_z.py
@@ -4,6 +4,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from .unke_hparams import unkeHyperParams
 from ...util import nethook
+from ...util.device import get_model_device
 
 
 
@@ -30,9 +31,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     #print("Computing right vector (v)")
+    device = get_model_device(model, fallback=getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok(data["answer"], return_tensors="pt").to("cuda")[
+    target_ids = tok(data["answer"], return_tensors="pt").to(device)[
         "input_ids"
     ][0]  
     
@@ -42,11 +44,11 @@ def compute_z(
         [data["question"]],  
         return_tensors="pt",
         padding=True,
-    ).to("cuda")
+    ).to(device)
     
     input_ids = torch.cat([input_tok['input_ids'],torch.unsqueeze(target_ids[:-1], dim=0)],dim=1)
     
-    rewriting_targets = torch.tensor(-100, device="cuda").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         1, len(input_ids[0])
     )
    
@@ -62,9 +64,9 @@ def compute_z(
     loss_layer = max(hparams.v_loss_layer, layer)
     
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init = None

--- a/easyeditor/models/unke/unke_main.py
+++ b/easyeditor/models/unke/unke_main.py
@@ -6,6 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from .compute_z import compute_z
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from ...util import nethook
+from ...util.device import get_model_device
 import torch.optim as optim
 
 import argparse
@@ -21,7 +22,8 @@ def compute_ks(
     hparams: unkeHyperParams,
     layer: int,
 ):
-    input_ids = tok(batch_data, padding=True,return_tensors="pt").to("cuda")
+    device = get_model_device(model, fallback=getattr(hparams, "device", None))
+    input_ids = tok(batch_data, padding=True,return_tensors="pt").to(device)
     idxs = [i.sum()-1 for i in input_ids['attention_mask']]
     with torch.no_grad():
         with nethook.Trace(

--- a/easyeditor/models/unke_ARE/compute_z.py
+++ b/easyeditor/models/unke_ARE/compute_z.py
@@ -4,6 +4,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from .unke_ARE_hparams import unkeAREHyperParams
 from ...util import nethook
+from ...util.device import get_model_device
 import nltk
 
 
@@ -30,9 +31,10 @@ def compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     #print("Computing right vector (v)")
+    device = get_model_device(model, fallback=getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok(data["answer"], return_tensors="pt").to("cuda")[
+    target_ids = tok(data["answer"], return_tensors="pt").to(device)[
         "input_ids"
     ][0]  
     
@@ -43,7 +45,7 @@ def compute_z(
         [data["question"]],  
         return_tensors="pt",
         padding=True,
-    ).to("cuda")
+    ).to(device)
 
     cur_input_ids = input_tok['input_ids'] 
     all_delta = []
@@ -55,7 +57,7 @@ def compute_z(
     #     if i > 0  and sen[0]!=" ":
     #         sen = " " + sen
     #     cur_sen = cur_sen + sen
-    #     current_target_ids = tok(cur_sen, return_tensors="pt").to("cuda")["input_ids"][0]
+    #     current_target_ids = tok(cur_sen, return_tensors="pt").to(device)["input_ids"][0]
     #     if current_target_ids[0] == tok.bos_token_id or current_target_ids[0] == tok.unk_token_id:
     #         current_target_ids = current_target_ids[1:]
     #     # if len(current_target_ids) < hparams.window_size:
@@ -79,7 +81,7 @@ def compute_z(
         
         start += hparams.window_size - hparams.overlap
         
-        rewriting_targets = torch.tensor(-100, device="cuda").repeat(
+        rewriting_targets = torch.tensor(-100, device=device).repeat(
             1, len(input_ids[0])
         )
    
@@ -93,9 +95,9 @@ def compute_z(
         loss_layer = max(hparams.v_loss_layer, layer)
     
         if hasattr(model.config, 'n_embd'):
-            delta = torch.zeros((model.config.n_embd,), requires_grad=True, device="cuda")
+            delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
         elif hasattr(model.config, 'hidden_size'):
-            delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device="cuda")
+            delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
         else:
             raise NotImplementedError
         target_init = None

--- a/easyeditor/models/unke_ARE/unke_ARE_main.py
+++ b/easyeditor/models/unke_ARE/unke_ARE_main.py
@@ -5,6 +5,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from .compute_z import compute_z
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from ...util import nethook
+from ...util.device import get_model_device
 import torch.optim as optim
 
 import argparse
@@ -21,7 +22,8 @@ def compute_ks(
     layer: int,
     idxs_dict:dict,
 ):
-    input_ids = tok(batch_data, padding=True,return_tensors="pt").to("cuda")
+    device = get_model_device(model, fallback=getattr(hparams, "device", None))
+    input_ids = tok(batch_data, padding=True,return_tensors="pt").to(device)
     zs_out_dict = {}
 
     with torch.no_grad():

--- a/easyeditor/models/wise/WISE.py
+++ b/easyeditor/models/wise/WISE.py
@@ -503,7 +503,7 @@ class WISEAdapter(torch.nn.Module):
         p_size = self.new_weight.grad.size()
         p_grad = self.new_weight.grad.reshape(-1)
 
-        # mask = torch.from_numpy(np.random.choice([0, 1], size=p_grad.size()[0], p=[.1, .9])).cuda()
+        # mask = torch.from_numpy(np.random.choice([0, 1], size=p_grad.size()[0], p=[.1, .9])).to(p_grad.device)
         p_grad = p_grad * self.weight_mask
         self.new_weight.grad = p_grad.view(p_size).to(self.new_weight.grad.dtype)
 

--- a/easyeditor/models/wise/wise_main.py
+++ b/easyeditor/models/wise/wise_main.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from .WISE import WISE, WISEMultimodal
 from .utils import tokenize, multimodal_tokenize, get_context_templates, blip2_multimodal_tokenize
 from .wise_hparams import WISEHyperParams
+from ...util.device import normalize_device
 WISEload = True
 def apply_wise_to_model(
         model: AutoModelForCausalLM,
@@ -15,7 +16,7 @@ def apply_wise_to_model(
 ) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
     if copy:
         model = deepcopy(model)
-    device = f'cuda:{hparams.device}'
+    device = normalize_device(getattr(hparams, "device", None))
     context_templates = get_context_templates(model, tok, length_params=[[5,5], [10,5]], device=device)
     editor = WISE(model=model, config=hparams, device=device)
     import os
@@ -45,7 +46,7 @@ def apply_wise_to_multimodal_model(
         copy=False,
         **kwargs: Any,
 ) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
-    device = f'cuda:{hparams.device}'    
+    device = normalize_device(getattr(hparams, "device", None))
     if copy:
         model = deepcopy(model)
         model.to(device)

--- a/easyeditor/trainer/algs/MALMEN.py
+++ b/easyeditor/trainer/algs/MALMEN.py
@@ -23,6 +23,7 @@ from .malmen.util import (
     kl_div,
     succ_ratios
 )
+from ...util.device import normalize_device
 
 from ..utils import (
     EarlyStopper,
@@ -57,8 +58,7 @@ class MALMEN(EditableModel):
         elif 'mistral' in config.model_name.lower():
             self.shift = True
 
-        if not str(self.config.device).startswith('cuda'):
-            self.config.device = f'cuda:{self.config.device}'
+        self.config.device = str(normalize_device(getattr(self.config, "device", None)))
         
         if config.half:
             self.model.bfloat16()

--- a/easyeditor/trainer/algs/MEND.py
+++ b/easyeditor/trainer/algs/MEND.py
@@ -17,6 +17,7 @@ from higher.patch import (
     make_functional,
 )
 from .patch import monkeypatch as _make_functional
+from ...util.device import normalize_device
 
 from . import local_nn
 from .editable_model import EditableModel
@@ -174,8 +175,7 @@ class MEND(EditableModel):
     def __init__(self, model, config, model_constructor, mend=None, edit_lrs=None):
         super().__init__(model, config, model_constructor)
 
-        if not str(self.config.device).startswith('cuda'):
-            self.config.device = f'cuda:{self.config.device}'
+        self.config.device = str(normalize_device(getattr(self.config, "device", None)))
 
         for n, p in model.named_parameters():
             if n not in self.config.inner_params:
@@ -454,12 +454,13 @@ if __name__ == "__main__":
     config.n_hidden = 1
     config = config.__dict__
 
-    mend = MEND(model, config, lambda: copy.deepcopy(model)).cuda()
+    device = normalize_device(None)
+    mend = MEND(model, config, lambda: copy.deepcopy(model)).to(device)
     import pdb
 
     pdb.set_trace()
     mend.load_state_dict(torch.load("test_state.pt"))
-    x = torch.arange(20).view(1, 20).cuda() + 1000
+    x = torch.arange(20, device=device).view(1, 20) + 1000
     orig_logits = mend(x)
     edited = mend.edit(x, masks=torch.ones_like(x), labels=x)
     post_logits = mend(x)

--- a/easyeditor/trainer/algs/SERAC.py
+++ b/easyeditor/trainer/algs/SERAC.py
@@ -7,6 +7,7 @@ from ..utils import scr, set_dropout, _logits, add_padding, add_sep
 from .editable_model import EditableModel
 from ..models import BertClassifier
 from transformers import GPT2Tokenizer, GPT2TokenizerFast
+from ...util.device import normalize_device
 
 LOG = logging.getLogger(__name__)
 
@@ -23,8 +24,7 @@ class SERAC(EditableModel):
                  scale=None):
         super().__init__(model, config, model_constructor)
 
-        if not str(self.config.device).startswith('cuda'):
-            self.config.device = f'cuda:{self.config.device}'
+        self.config.device = str(normalize_device(getattr(self.config, "device", None)))
         if classifier is None:
             if config.cross_attend and not config.cls_class.endswith("ForSequenceClassification"):
                 LOG.warn(f"Switching {config.cls_class} to {config.cls_class}ForSequenceClassification for cross-attend")
@@ -931,11 +931,12 @@ if __name__ == '__main__':
     config.gtn.n_hidden = 1
     config.gtn = config.gtn.__dict__
 
-    gtn = SERAC(model, config, lambda: copy.deepcopy(model)).cuda()
+    device = normalize_device(None)
+    gtn = SERAC(model, config, lambda: copy.deepcopy(model)).to(device)
     # torch.save(gtn.state_dict(), "test_state.pt")
     import pdb; pdb.set_trace()
     gtn.load_state_dict(torch.load("test_state.pt"))
-    x = torch.arange(20).view(1, 20).cuda() + 1000
+    x = torch.arange(20, device=device).view(1, 20) + 1000
     orig_logits = gtn(x)
     edited = gtn.edit(x, masks=torch.ones_like(x), labels=x)
     post_logits = gtn(x)

--- a/easyeditor/trainer/blip2_models/common/logger.py
+++ b/easyeditor/trainer/blip2_models/common/logger.py
@@ -40,7 +40,8 @@ class SmoothedValue(object):
         """
         if not is_dist_avail_and_initialized():
             return
-        t = torch.tensor([self.count, self.total], dtype=torch.float64, device="cuda")
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        t = torch.tensor([self.count, self.total], dtype=torch.float64, device=device)
         dist.barrier()
         dist.all_reduce(t)
         t = t.tolist()

--- a/easyeditor/trainer/blip2_models/eva_vit.py
+++ b/easyeditor/trainer/blip2_models/eva_vit.py
@@ -442,6 +442,6 @@ def create_eva_vit_g(img_size=224,drop_path_rate=0.4,use_checkpoint=False,precis
 #     print(incompatible_keys)
     
     if precision == "fp16":
-#         model.to("cuda") 
+#         model.to(device)
         convert_weights_to_fp16(model)
     return model

--- a/easyeditor/util/device.py
+++ b/easyeditor/util/device.py
@@ -1,0 +1,63 @@
+from collections.abc import Mapping
+
+import torch
+
+
+def normalize_device(device=None, *, default_cuda=True):
+    if isinstance(device, torch.device):
+        return device
+
+    if device is None:
+        if default_cuda and torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
+    if isinstance(device, int):
+        return torch.device(f"cuda:{device}")
+
+    device_str = str(device).strip()
+    if device_str == "":
+        return normalize_device(None, default_cuda=default_cuda)
+
+    if device_str.isdigit():
+        return torch.device(f"cuda:{device_str}")
+
+    return torch.device(device_str)
+
+
+def move_to_device(obj, device):
+    target_device = normalize_device(device)
+
+    if hasattr(obj, "to"):
+        return obj.to(target_device)
+
+    if isinstance(obj, Mapping):
+        return type(obj)((key, move_to_device(value, target_device)) for key, value in obj.items())
+
+    if isinstance(obj, tuple):
+        return tuple(move_to_device(item, target_device) for item in obj)
+
+    if isinstance(obj, list):
+        return [move_to_device(item, target_device) for item in obj]
+
+    return obj
+
+
+def get_model_device(model, fallback=None):
+    if model is not None and hasattr(model, "device"):
+        return normalize_device(model.device)
+
+    if model is not None:
+        try:
+            return next(model.parameters()).device
+        except (AttributeError, StopIteration):
+            pass
+
+    return normalize_device(fallback)
+
+
+def copy_to_param(param, value):
+    with torch.no_grad():
+        if not torch.is_tensor(value):
+            value = torch.as_tensor(value)
+        param[...] = value.to(device=param.device, dtype=param.dtype)

--- a/easyeditor/util/generate.py
+++ b/easyeditor/util/generate.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from .device import normalize_device
 from .logit_lens import LogitLens
 
 
@@ -181,7 +182,7 @@ def generate_standard(model, prompt, tokenizer, max_input_tokens=256, max_new_to
         tokenizer.padding_side = 'left'
         right_pad_flag=True
 
-    inputs = tokenizer(prompt, padding = True, truncation = True, max_length = max_input_tokens, return_tensors = "pt").to('cuda')
+    inputs = tokenizer(prompt, padding = True, truncation = True, max_length = max_input_tokens, return_tensors = "pt").to(normalize_device())
 
     with torch.no_grad():
         outputs = model.generate(

--- a/easyeditor/util/perplexity.py
+++ b/easyeditor/util/perplexity.py
@@ -1,6 +1,8 @@
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from .device import get_model_device
+
 
 def perplexity(
     model: AutoModelForCausalLM,
@@ -13,9 +15,10 @@ def perplexity(
     Text is truncated to max_input_length tokens.
     """
 
+    device = get_model_device(model)
     inputs = tok(
         [text], return_tensors="pt", max_length=max_input_length, truncation=True
-    ).to("cuda")
+    ).to(device)
 
     logits = torch.nn.functional.log_softmax(model(**inputs).logits, dim=2)
     log_probs = torch.gather(logits[:, :-1, :], 2, inputs["input_ids"][:, 1:, None])[0]


### PR DESCRIPTION
## Summary
- Add shared device helpers for int/string/torch.device/cpu/default CUDA handling.
- Replace brittle CUDA device assumptions across editors, evaluation, algorithms, and trainer paths.
- Make parameter restore/writeback follow destination parameter device and dtype.
- Fix EAMET package imports and remove an unused random_word dependency.
- Strengthen device-handling regression checks with global source scanning.

## Tests
- git diff --check
- py_compile over easyeditor/**/*.py
- check_device_handling_contract.py --strict-static
- package import smoke for EAMET/CORE/AlphaEdit/SPHERE/MEND/SERAC/MALMEN/UltraEdit
- GPU smoke on A800_2 with CUDA_VISIBLE_DEVICES=1: FT, ROME, MEMIT, PMET, EMMET using device: 0 and device: cuda:0