### PR TITLE
Add forward-propagation target construction method for multi-layer parameter editing

### DIFF
--- a/easyeditor/editors/batch_editor.py
+++ b/easyeditor/editors/batch_editor.py
@@ -7,6 +7,7 @@ class BatchEditor(Enum):
     KE = 'KE'
     MEND = 'MEND'
     MEMIT = 'MEMIT'
+    MEMIT_FE = 'MEMIT-FE'
     PMET = 'PMET'
     FT = 'FT'
     QLoRA = 'QLoRA'
@@ -25,6 +26,7 @@ class BatchEditor(Enum):
             or alg_name == BatchEditor.KE.value \
             or alg_name == BatchEditor.MEND.value \
             or alg_name == BatchEditor.MEMIT.value \
+            or alg_name == BatchEditor.MEMIT_FE.value \
             or alg_name == BatchEditor.PMET.value \
             or alg_name == BatchEditor.FT.value \
             or alg_name == BatchEditor.QLoRA.value \

--- a/easyeditor/models/__init__.py
+++ b/easyeditor/models/__init__.py
@@ -2,6 +2,7 @@ from .ft import *
 from .ike import *
 from .kn import *
 from .memit import *
+from .memit_FE import *
 from .mend import *
 from .rome import *
 from .serac import *

--- a/easyeditor/models/memit_FE/__init__.py
+++ b/easyeditor/models/memit_FE/__init__.py
@@ -1,0 +1,1 @@
+from .memit_FE_main import MEMITFEHyperParams, apply_memit_FE_to_model

--- a/easyeditor/models/memit_FE/compute_ks.py
+++ b/easyeditor/models/memit_FE/compute_ks.py
@@ -1,0 +1,50 @@
+from typing import Dict, List
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .compute_z import get_module_input_output_at_words
+from .memit_FE_hparams import MEMITFEHyperParams
+
+
+def compute_ks(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    requests: Dict,
+    hparams: MEMITFEHyperParams,
+    layer: int,
+    context_templates: List[str],
+):
+    layer_ks = get_module_input_output_at_words(
+        model,
+        tok,
+        layer,
+        context_templates=[
+            context.format(request["prompt"])
+            for request in requests
+            for context_type in context_templates
+            for context in context_type
+        ],
+        words=[
+            request["subject"]
+            for request in requests
+            for context_type in context_templates
+            for _ in context_type
+        ],
+        module_template=hparams.rewrite_module_tmp,
+        fact_token_strategy=hparams.fact_token,
+    )[0]
+
+    context_type_lens = [0] + [len(context_type) for context_type in context_templates]
+    context_len = sum(context_type_lens)
+    context_type_csum = np.cumsum(context_type_lens).tolist()
+
+    ans = []
+    for i in range(0, layer_ks.size(0), context_len):
+        tmp = []
+        for j in range(len(context_type_csum) - 1):
+            start, end = context_type_csum[j], context_type_csum[j + 1]
+            tmp.append(layer_ks[i + start : i + end].mean(0))
+        ans.append(torch.stack(tmp, 0).mean(0))
+    return torch.stack(ans, dim=0)

--- a/easyeditor/models/memit_FE/compute_z.py
+++ b/easyeditor/models/memit_FE/compute_z.py
@@ -7,6 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
+from ...util.device import normalize_device
 
 from .memit_FE_hparams import MEMITFEHyperParams
 
@@ -50,13 +51,16 @@ def compute_z(
         print(f"Direct computation for layer {first_layer} returned None. Returning None.")
         return None
 
-    zs_dict[first_layer] = first_layer_z
+    zs_dict[first_layer] = first_layer_z.detach().clone()
 
 
     # Forward propagation
+    device = normalize_device(getattr(hparams, "device", None))
     other_layers = z_layers[1:]
     prompt = request["prompt"].format(request["subject"])
-    input_tok = tok(prompt, return_tensors="pt").to(f"cuda:{hparams.device}")
+    input_tok = tok(prompt, return_tensors="pt").to(device)
+
+    seq_len = input_tok["input_ids"].shape[1]
     
     # Find lookup index
     lookup_idx = find_fact_lookup_idx(
@@ -67,15 +71,32 @@ def compute_z(
         verbose=False
     )
     
+    # def edit_output_fn(cur_out, cur_layer_name):
+    #     first_layer_module = hparams.layer_module_tmp.format(first_layer)
+    #     # Inject the first layer z into the forward pass when we reach the first layer
+    #     if cur_layer_name == first_layer_module:
+    #         z_to_inject = zs_dict[first_layer]
+    #         if cur_out[0].shape[0] == 1:
+    #             cur_out[0][0, lookup_idx, :] = z_to_inject
+    #         else:
+    #             cur_out[0][lookup_idx, 0, :] = z_to_inject
+    #     return cur_out
+
     def edit_output_fn(cur_out, cur_layer_name):
         first_layer_module = hparams.layer_module_tmp.format(first_layer)
-        # Inject the first layer z into the forward pass when we reach the first layer
         if cur_layer_name == first_layer_module:
+            layer_output = nethook.get_hidden_state(cur_out)  
             z_to_inject = zs_dict[first_layer]
-            if cur_out[0].shape[0] == 1:
-                cur_out[0][0, lookup_idx, :] = z_to_inject
+            
+            if layer_output.shape[0] == 1: 
+                layer_output[0, lookup_idx, :] = z_to_inject
             else:
-                cur_out[0][lookup_idx, 0, :] = z_to_inject
+                if layer_output.shape[1] == seq_len: # [batch, seq, dim]
+                    layer_output[:, lookup_idx, :] = z_to_inject
+                else: # [seq, batch, dim]
+                    layer_output[lookup_idx, :, :] = z_to_inject
+                    
+            return nethook.replace_hidden_state(cur_out, layer_output)
         return cur_out
     
     with torch.no_grad():
@@ -87,22 +108,31 @@ def compute_z(
         ) as tr:
             model(**input_tok)
         
-        # Extract z from each layer
-        for layer in other_layers:
-            layer_module = hparams.layer_module_tmp.format(layer)
-            output = tr[layer_module].output
-            c_z_raw = output[0] if isinstance(output, tuple) else output
-            
-            # Extract at lookup position
-            if c_z_raw.dim() == 3:
-                c_z = c_z_raw[0, lookup_idx, :] if c_z_raw.shape[0] == 1 else c_z_raw[lookup_idx, 0, :]
-            else:
-                c_z = c_z_raw[lookup_idx, :]
-            
-            zs_dict[layer]=c_z.detach().clone()
-            print()
-            print(f"Computed z for layer {layer} during forward pass.")
-            print(f"Norm of z for layer {layer}: {zs_dict[layer].norm().item()}")
+            # Extract z from each layer
+            for layer in other_layers:
+                layer_module = hparams.layer_module_tmp.format(layer)
+                output = tr[layer_module].output
+                c_z_raw = nethook.get_hidden_state(output)
+                # c_z_raw = output[0] if isinstance(output, tuple) else output
+                
+                # # Extract at lookup position
+                # if c_z_raw.dim() == 3:
+                #     c_z = c_z_raw[0, lookup_idx, :] if c_z_raw.shape[0] == 1 else c_z_raw[lookup_idx, 0, :]
+                # else:
+                #     c_z = c_z_raw[lookup_idx, :]
+
+                if c_z_raw.dim() == 3:
+                    if c_z_raw.shape[1] == seq_len:  # [Batch, Seq, Dim]
+                        c_z = c_z_raw[0, lookup_idx, :] if c_z_raw.shape[0] == 1 else c_z_raw[:, lookup_idx, :]
+                    else:                             # [Seq, Batch, Dim]
+                        c_z = c_z_raw[lookup_idx, 0, :] if c_z_raw.shape[1] == 1 else c_z_raw[lookup_idx, :, :]
+                else:
+                    c_z = c_z_raw[lookup_idx, :]
+                
+                zs_dict[layer]=c_z.detach().clone()
+                print()
+                print(f"Computed z for layer {layer} during forward pass.")
+                print(f"Norm of z for layer {layer}: {zs_dict[layer].norm().item()}")
     
     return zs_dict
 
@@ -130,9 +160,10 @@ def _direct_compute_z(
         lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
 
     print("Computing right vector (v)")
+    device = normalize_device(getattr(hparams, "device", None))
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False)[0].to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -148,10 +179,10 @@ def _direct_compute_z(
         [prompt.format(request["subject"]) for prompt in all_prompts],
         return_tensors="pt",
         padding=True,
-    ).to(f"cuda:{hparams.device}")
+    ).to(device)
 
     # Compute rewriting targets
-    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+    rewriting_targets = torch.tensor(-100, device=device).repeat(
         len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
     )
     for i in range(len(rewriting_prompts)):
@@ -175,9 +206,9 @@ def _direct_compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -186,80 +217,26 @@ def _direct_compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        def _unwrap_output(output):
-            if isinstance(output, torch.Tensor):
-                return output, None
-            if isinstance(output, (list, tuple)):
-                if len(output) == 0:
-                    raise ValueError("Layer output container is empty.")
-                return output[0], output
-            raise TypeError(
-                f"Unsupported layer output type {type(output)} encountered in MEMIT."
-            )
-
-        def _rewrap_output(updated, original):
-            if original is None:
-                return updated
-            if isinstance(original, list):
-                new_out = list(original)
-            elif isinstance(original, tuple):
-                new_out = list(original)
-            else:
-                raise TypeError(
-                    f"Unsupported layer output container {type(original)} in MEMIT."
-                )
-            new_out[0] = updated
-            return type(original)(new_out) if isinstance(original, tuple) else new_out
-    
-        if isinstance(cur_out, tuple):
-            output_tensor = cur_out[0]
-            is_tuple = True
-        else:
-            output_tensor = cur_out
-            is_tuple = False
-        
         if cur_layer == hparams.layer_module_tmp.format(layer):
+            layer_output = nethook.get_hidden_state(cur_out)
 
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
-                target_init = output_tensor[0, lookup_idxs[0]].detach().clone()
-
+                # Initial value is recorded for the clean sentence
+                target_init = layer_output[0, lookup_idxs[0]].detach().clone()
 
             # Add intervened delta
-            new_output = output_tensor.clone()
-            
             for i, idx in enumerate(lookup_idxs):
-                if len(lookup_idxs) != new_output.shape[0]:
-                    new_output[idx, i, :] = new_output[idx, i, :] + delta
+
+                if len(lookup_idxs)!=layer_output.shape[0]:
+                    layer_output[idx, i, :] += delta
                 else:
-                    new_output[i, idx, :] = new_output[i, idx, :] + delta
-            
-            if is_tuple:
-                return (new_output,) + cur_out[1:]
-            return new_output
-        
+                    layer_output[i, idx, :] += delta
+
+            return nethook.replace_hidden_state(cur_out, layer_output)
+
         return cur_out
-
-        # if cur_layer == hparams.layer_module_tmp.format(layer):
-        #     layer_output, original_container = _unwrap_output(cur_out)
-
-        #     # Store initial value of the vector of interest
-        #     if target_init is None:
-        #         print("Recording initial value of v*")
-        #         target_init = layer_output[0, lookup_idxs[0]].detach().clone()
-
-        #     # Add intervened delta
-        #     for i, idx in enumerate(lookup_idxs):
-
-        #         if len(lookup_idxs)!=layer_output.shape[0]:
-        #             layer_output[idx, i, :] += delta
-        #         else:
-        #             layer_output[i, idx, :] += delta
-
-        #     return _rewrap_output(layer_output, original_container)
-
-        # return cur_out
 
     # Optimizer
     opt = torch.optim.Adam([delta], lr=hparams.v_lr)
@@ -295,11 +272,13 @@ def _direct_compute_z(
 
         # Compute loss on rewriting targets
 
-        loss_layer_out = tr[hparams.layer_module_tmp.format(loss_layer)].output
-        if isinstance(loss_layer_out, (list, tuple)):
-            output = loss_layer_out[0]
-        else:
-            output = loss_layer_out
+        output = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)
+
+        # loss_layer_out = tr[hparams.layer_module_tmp.format(loss_layer)].output
+        # if isinstance(loss_layer_out, (list, tuple)):
+        #     output = loss_layer_out[0]
+        # else:
+        #     output = loss_layer_out
 
         if output.shape[1]!=rewriting_targets.shape[1]:
             output=torch.transpose(output, 0, 1)

--- a/easyeditor/models/memit_FE/compute_z.py
+++ b/easyeditor/models/memit_FE/compute_z.py
@@ -41,6 +41,8 @@ def compute_z(
             context_templates=context_templates,
         )
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         print(f"Error computing z for layer {first_layer} due to {e}. Returning None.")
         return None
     
@@ -91,14 +93,16 @@ def compute_z(
             output = tr[layer_module].output
             c_z_raw = output[0] if isinstance(output, tuple) else output
             
-            # Extract at lookup position (match memit_a_main.py logic)
+            # Extract at lookup position
             if c_z_raw.dim() == 3:
                 c_z = c_z_raw[0, lookup_idx, :] if c_z_raw.shape[0] == 1 else c_z_raw[lookup_idx, 0, :]
             else:
                 c_z = c_z_raw[lookup_idx, :]
             
             zs_dict[layer]=c_z.detach().clone()
+            print()
             print(f"Computed z for layer {layer} during forward pass.")
+            print(f"Norm of z for layer {layer}: {zs_dict[layer].norm().item()}")
     
     return zs_dict
 
@@ -128,7 +132,7 @@ def _direct_compute_z(
     print("Computing right vector (v)")
 
     # Tokenize target into list of int token IDs
-    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False)[0].to(f"cuda:{hparams.device}")[0]
 
     if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
         target_ids = target_ids[1:]
@@ -206,27 +210,56 @@ def _direct_compute_z(
                 )
             new_out[0] = updated
             return type(original)(new_out) if isinstance(original, tuple) else new_out
-
+    
+        if isinstance(cur_out, tuple):
+            output_tensor = cur_out[0]
+            is_tuple = True
+        else:
+            output_tensor = cur_out
+            is_tuple = False
+        
         if cur_layer == hparams.layer_module_tmp.format(layer):
-            layer_output, original_container = _unwrap_output(cur_out)
 
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
-                # Initial value is recorded for the clean sentence
-                target_init = layer_output[0, lookup_idxs[0]].detach().clone()
+                target_init = output_tensor[0, lookup_idxs[0]].detach().clone()
+
 
             # Add intervened delta
+            new_output = output_tensor.clone()
+            
             for i, idx in enumerate(lookup_idxs):
-
-                if len(lookup_idxs)!=layer_output.shape[0]:
-                    layer_output[idx, i, :] += delta
+                if len(lookup_idxs) != new_output.shape[0]:
+                    new_output[idx, i, :] = new_output[idx, i, :] + delta
                 else:
-                    layer_output[i, idx, :] += delta
-
-            return _rewrap_output(layer_output, original_container)
-
+                    new_output[i, idx, :] = new_output[i, idx, :] + delta
+            
+            if is_tuple:
+                return (new_output,) + cur_out[1:]
+            return new_output
+        
         return cur_out
+
+        # if cur_layer == hparams.layer_module_tmp.format(layer):
+        #     layer_output, original_container = _unwrap_output(cur_out)
+
+        #     # Store initial value of the vector of interest
+        #     if target_init is None:
+        #         print("Recording initial value of v*")
+        #         target_init = layer_output[0, lookup_idxs[0]].detach().clone()
+
+        #     # Add intervened delta
+        #     for i, idx in enumerate(lookup_idxs):
+
+        #         if len(lookup_idxs)!=layer_output.shape[0]:
+        #             layer_output[idx, i, :] += delta
+        #         else:
+        #             layer_output[i, idx, :] += delta
+
+        #     return _rewrap_output(layer_output, original_container)
+
+        # return cur_out
 
     # Optimizer
     opt = torch.optim.Adam([delta], lr=hparams.v_lr)
@@ -296,6 +329,7 @@ def _direct_compute_z(
             f"avg prob of [{request['target_new']}] "
             f"{torch.exp(-nll_loss_each).mean().item()}"
         )
+
         if loss < 5e-2:
             break
 

--- a/easyeditor/models/memit_FE/compute_z.py
+++ b/easyeditor/models/memit_FE/compute_z.py
@@ -1,0 +1,411 @@
+from typing import Dict, List, Tuple
+from copy import deepcopy
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from ..rome import repr_tools
+from ...util import nethook
+
+from .memit_FE_hparams import MEMITFEHyperParams
+
+def compute_z(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    request: Dict,
+    hparams: MEMITFEHyperParams,
+    z_layers: List[int],
+    context_templates: List[str],
+) -> Dict[int, torch.Tensor]:
+    """
+    A unified function that use FE methods to calculate targets for multiple layers.
+    Calculate the first layer target by _direct_compute_z().
+    Perform forward propagation for the rest of the layers.
+    """
+
+    request_cp = deepcopy(request)
+    z_layers = sorted(z_layers)
+    zs_dict = {layer: None for layer in z_layers}  # Store computed z for each layer here, to be returned at the end
+
+    # Directly compute the target for the first layer
+    first_layer = z_layers[0]
+    print(f"Calculate target for the first layer {first_layer}")
+    try:
+        first_layer_z = _direct_compute_z(
+            model=model,
+            tok=tok,
+            request=request_cp,
+            hparams=hparams,
+            layer=first_layer,
+            context_templates=context_templates,
+        )
+    except Exception as e:
+        print(f"Error computing z for layer {first_layer} due to {e}. Returning None.")
+        return None
+    
+    if first_layer_z is None:
+        print(f"Direct computation for layer {first_layer} returned None. Returning None.")
+        return None
+
+    zs_dict[first_layer] = first_layer_z
+
+
+    # Forward propagation
+    other_layers = z_layers[1:]
+    prompt = request["prompt"].format(request["subject"])
+    input_tok = tok(prompt, return_tensors="pt").to(f"cuda:{hparams.device}")
+    
+    # Find lookup index
+    lookup_idx = find_fact_lookup_idx(
+        request["prompt"], 
+        request["subject"], 
+        tok, 
+        hparams.fact_token, 
+        verbose=False
+    )
+    
+    def edit_output_fn(cur_out, cur_layer_name):
+        first_layer_module = hparams.layer_module_tmp.format(first_layer)
+        # Inject the first layer z into the forward pass when we reach the first layer
+        if cur_layer_name == first_layer_module:
+            z_to_inject = zs_dict[first_layer]
+            if cur_out[0].shape[0] == 1:
+                cur_out[0][0, lookup_idx, :] = z_to_inject
+            else:
+                cur_out[0][lookup_idx, 0, :] = z_to_inject
+        return cur_out
+    
+    with torch.no_grad():
+        with nethook.TraceDict(
+            module=model,
+            layers=[hparams.layer_module_tmp.format(l) for l in z_layers],  
+            # Must trace ALL layers including first_layer!
+            edit_output=edit_output_fn,
+        ) as tr:
+            model(**input_tok)
+        
+        # Extract z from each layer
+        for layer in other_layers:
+            layer_module = hparams.layer_module_tmp.format(layer)
+            output = tr[layer_module].output
+            c_z_raw = output[0] if isinstance(output, tuple) else output
+            
+            # Extract at lookup position (match memit_a_main.py logic)
+            if c_z_raw.dim() == 3:
+                c_z = c_z_raw[0, lookup_idx, :] if c_z_raw.shape[0] == 1 else c_z_raw[lookup_idx, 0, :]
+            else:
+                c_z = c_z_raw[lookup_idx, :]
+            
+            zs_dict[layer]=c_z.detach().clone()
+            print(f"Computed z for layer {layer} during forward pass.")
+    
+    return zs_dict
+
+def _direct_compute_z(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    request: Dict,
+    hparams: MEMITFEHyperParams,
+    layer: int,
+    context_templates: List[str],
+) -> torch.Tensor:
+    """
+    Computes the value (right) vector for the rank-1 update.
+    Runs a simple optimization procedure.
+    """
+
+    # Get model parameters
+    lm_w, ln_f = (
+        nethook.get_parameter(model, f"{hparams.lm_head_module}.weight").T,
+        nethook.get_module(model, hparams.ln_f_module),
+    )
+    try:
+        lm_b = nethook.get_parameter(model, f"{hparams.lm_head_module}.bias")
+    except LookupError as _:
+        lm_b = next(model.parameters()).new_zeros(model.config.vocab_size)
+
+    print("Computing right vector (v)")
+
+    # Tokenize target into list of int token IDs
+    target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(f"cuda:{hparams.device}")[0]
+
+    if target_ids[0] == tok.bos_token_id or target_ids[0] == tok.unk_token_id:
+        target_ids = target_ids[1:]
+    # Compile list of rewriting and KL x/y pairs
+    rewriting_prompts, kl_prompts = [
+        context.format(request["prompt"]) + tok.decode(target_ids[:-1])
+        for context_types in context_templates
+        for context in context_types
+    ], ["{} is a"]
+    all_prompts = rewriting_prompts + kl_prompts
+
+    input_tok = tok(
+        [prompt.format(request["subject"]) for prompt in all_prompts],
+        return_tensors="pt",
+        padding=True,
+    ).to(f"cuda:{hparams.device}")
+
+    # Compute rewriting targets
+    rewriting_targets = torch.tensor(-100, device=f"cuda:{hparams.device}").repeat(
+        len(rewriting_prompts), *input_tok["input_ids"].shape[1:]
+    )
+    for i in range(len(rewriting_prompts)):
+        ex_len = input_tok["attention_mask"][i].sum()
+        rewriting_targets[i, ex_len - len(target_ids) : ex_len] = target_ids
+
+    # Compute indices of the tokens where the fact is looked up
+    lookup_idxs = [
+        find_fact_lookup_idx(
+            prompt, request["subject"], tok, hparams.fact_token, verbose=(i == 0)
+        )
+        for i, prompt in enumerate(all_prompts)
+    ]
+
+    # Finalize rewrite and loss layers
+    loss_layer = max(hparams.v_loss_layer, layer)
+    print(f"Rewrite layer is {layer}")
+    print(f"Tying optimization objective to {loss_layer}")
+
+    # Set up an optimization over a latent vector that, when output at the
+    # rewrite layer, i.e. hypothesized fact lookup location, will induce the
+    # target token to be predicted at the final layer.
+    if hasattr(model.config, 'n_embd'):
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=f"cuda:{hparams.device}")
+    elif hasattr(model.config, 'hidden_size'):
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=f"cuda:{hparams.device}")
+    else:
+        raise NotImplementedError
+    target_init, kl_distr_init = None, None
+
+    # Inserts new "delta" variable at the appropriate part of the computation
+    def edit_output_fn(cur_out, cur_layer):
+        nonlocal target_init
+
+        def _unwrap_output(output):
+            if isinstance(output, torch.Tensor):
+                return output, None
+            if isinstance(output, (list, tuple)):
+                if len(output) == 0:
+                    raise ValueError("Layer output container is empty.")
+                return output[0], output
+            raise TypeError(
+                f"Unsupported layer output type {type(output)} encountered in MEMIT."
+            )
+
+        def _rewrap_output(updated, original):
+            if original is None:
+                return updated
+            if isinstance(original, list):
+                new_out = list(original)
+            elif isinstance(original, tuple):
+                new_out = list(original)
+            else:
+                raise TypeError(
+                    f"Unsupported layer output container {type(original)} in MEMIT."
+                )
+            new_out[0] = updated
+            return type(original)(new_out) if isinstance(original, tuple) else new_out
+
+        if cur_layer == hparams.layer_module_tmp.format(layer):
+            layer_output, original_container = _unwrap_output(cur_out)
+
+            # Store initial value of the vector of interest
+            if target_init is None:
+                print("Recording initial value of v*")
+                # Initial value is recorded for the clean sentence
+                target_init = layer_output[0, lookup_idxs[0]].detach().clone()
+
+            # Add intervened delta
+            for i, idx in enumerate(lookup_idxs):
+
+                if len(lookup_idxs)!=layer_output.shape[0]:
+                    layer_output[idx, i, :] += delta
+                else:
+                    layer_output[i, idx, :] += delta
+
+            return _rewrap_output(layer_output, original_container)
+
+        return cur_out
+
+    # Optimizer
+    opt = torch.optim.Adam([delta], lr=hparams.v_lr)
+    nethook.set_requires_grad(False, model)
+
+    # Execute optimization
+    for it in range(hparams.v_num_grad_steps):
+        opt.zero_grad()
+
+        # Forward propagation
+        with nethook.TraceDict(
+            module=model,
+            layers=[
+                hparams.layer_module_tmp.format(loss_layer),
+                hparams.layer_module_tmp.format(layer),
+            ],
+            retain_input=False,
+            retain_output=True,
+            edit_output=edit_output_fn,
+        ) as tr:
+            logits = model(**input_tok).logits
+            # Compute distribution for KL divergence
+            kl_logits = torch.stack(
+                [
+                    logits[i - len(kl_prompts), idx, :]
+                    for i, idx in enumerate(lookup_idxs[-len(kl_prompts) :])
+                ],
+                dim=0,
+            )
+            kl_log_probs = torch.nn.functional.log_softmax(kl_logits, dim=1)
+            if kl_distr_init is None:
+                kl_distr_init = kl_log_probs.detach().clone()
+
+        # Compute loss on rewriting targets
+
+        loss_layer_out = tr[hparams.layer_module_tmp.format(loss_layer)].output
+        if isinstance(loss_layer_out, (list, tuple)):
+            output = loss_layer_out[0]
+        else:
+            output = loss_layer_out
+
+        if output.shape[1]!=rewriting_targets.shape[1]:
+            output=torch.transpose(output, 0, 1)
+        full_repr = output[:len(rewriting_prompts)]
+
+        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        loss = torch.gather(
+            log_probs,
+            2,
+            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2).to(log_probs.device),
+        ).squeeze(2)
+        mask = (rewriting_targets != -100).float()
+
+        # Aggregate total losses
+        nll_loss_each = -(loss * mask.to(loss.device)).sum(1) / target_ids.size(0)
+        nll_loss = nll_loss_each.mean()
+        kl_loss = hparams.kl_factor * torch.nn.functional.kl_div(
+            kl_distr_init, kl_log_probs, log_target=True, reduction="batchmean"
+        )
+        weight_decay = hparams.v_weight_decay * (
+            torch.norm(delta) / torch.norm(target_init) ** 2
+        )
+        # weight_decay = hparams.v_weight_decay * torch.norm(delta) ** 2
+        loss = nll_loss + kl_loss.to(nll_loss.device) + weight_decay.to(nll_loss.device)
+        print(
+            f"loss {np.round(loss.item(), 3)} = {np.round(nll_loss.item(), 3)} + {np.round(kl_loss.item(), 3)} + {np.round(weight_decay.item(), 3)} "
+            f"avg prob of [{request['target_new']}] "
+            f"{torch.exp(-nll_loss_each).mean().item()}"
+        )
+        if loss < 5e-2:
+            break
+
+        if it == hparams.v_num_grad_steps - 1:
+            break
+
+        # Backpropagate
+        loss.backward()
+        opt.step()
+
+        # Project within L2 ball
+        max_norm = hparams.clamp_norm_factor * target_init.norm()
+        if delta.norm() > max_norm:
+            with torch.no_grad():
+                delta[...] = delta * max_norm / delta.norm()
+
+    target = target_init + delta
+    print(
+        f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
+    )
+
+    return target
+
+
+def get_module_input_output_at_words(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    layer: int,
+    context_templates: List[str],
+    words: List[str],
+    module_template: str,
+    fact_token_strategy: str,
+    track=None,
+) -> Tuple[torch.Tensor]:
+    """
+    Retrieves detached representations for a word at the input and
+    output of a particular layer module.
+    """
+
+    word_repr_args = dict(
+        model=model,
+        tok=tok,
+        layer=layer,
+        module_template=module_template,
+    )
+    if "subject_" in fact_token_strategy and fact_token_strategy.index("subject_") == 0:
+        context_info = dict(
+            context_templates=context_templates,
+            words=words,
+        )
+        subtoken = fact_token_strategy[len("subject_") :]
+        if track == 'out' or track == 'in':
+            return repr_tools.get_reprs_at_word_tokens(
+                track=track, subtoken=subtoken, **context_info, **word_repr_args
+            )
+        l_input, l_output = repr_tools.get_reprs_at_word_tokens(
+            track="both", subtoken=subtoken, **context_info, **word_repr_args
+        )
+    elif fact_token_strategy == "last":
+        raise Exception("This is definitely bugged, fix it.")
+        context_info = dict(
+            contexts=[
+                tmp[i].format(words[i]) for i, tmp in enumerate(context_templates)
+            ],
+            idxs=[000000],
+        )
+        if track == 'out' or track == 'in':
+            return repr_tools.get_reprs_at_word_tokens(
+                track=track, subtoken=subtoken, **context_info, **word_repr_args
+            )
+        l_input, l_output = repr_tools.get_reprs_at_idxs(
+            track="both", **context_info, **word_repr_args
+        )
+    else:
+        raise ValueError(f"fact_token={fact_token_strategy} not recognized")
+
+    return l_input.detach(), l_output.detach()
+
+
+def find_fact_lookup_idx(
+    prompt: str,
+    subject: str,
+    tok: AutoTokenizer,
+    fact_token_strategy: str,
+    verbose=True,
+) -> int:
+    """
+    Computes hypothesized fact lookup index given a sentence and subject.
+    """
+
+    ret = None
+    if fact_token_strategy == "last":
+        ret = -1
+    elif (
+        "subject_" in fact_token_strategy and fact_token_strategy.index("subject_") == 0
+    ):
+        ret = repr_tools.get_words_idxs_in_templates(
+            tok=tok,
+            context_templates=[prompt],
+            words=[subject],
+            subtoken=fact_token_strategy[len("subject_") :],
+        )[0][0]
+    else:
+        raise ValueError(f"fact_token={fact_token_strategy} not recognized")
+
+    sentence = prompt.format(subject)
+    if verbose:
+        print(
+            f"Lookup index found: {ret} | Sentence: {sentence} | Token:",
+            tok.decode(tok(sentence)["input_ids"][ret]),
+        )
+
+    return ret

--- a/easyeditor/models/memit_FE/memit_FE_hparams.py
+++ b/easyeditor/models/memit_FE/memit_FE_hparams.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import List, Literal
+
+from ...util.hparams import HyperParams
+import yaml
+
+
+@dataclass
+class MEMITFEHyperParams(HyperParams):
+    # Method
+    layers: List[int]
+    layer_selection: Literal["all", "random"]
+    fact_token: Literal[
+        "last", "subject_first", "subject_last", "subject_first_after_last"
+    ]
+    v_num_grad_steps: int
+    v_lr: float
+    v_loss_layer: int
+    v_weight_decay: float
+    clamp_norm_factor: float
+    kl_factor: float
+    mom2_adjustment: bool
+    mom2_update_weight: float
+
+    # Module templates
+    rewrite_module_tmp: str
+    layer_module_tmp: str
+    mlp_module_tmp: str
+    attn_module_tmp: str
+    ln_f_module: str
+    lm_head_module: str
+
+    # Statistics
+    mom2_dataset: str
+    mom2_n_samples: int
+    mom2_dtype: str
+    alg_name: str
+    device: int
+    model_name: str
+    stats_dir: str
+
+    max_length: int = 40
+    batch_size: int = 1
+    model_parallel: bool = False
+
+    @classmethod
+    def from_hparams(cls, hparams_name_or_path: str):
+
+        if '.yaml' not in hparams_name_or_path:
+            hparams_name_or_path = hparams_name_or_path + '.yaml'
+
+        with open(hparams_name_or_path, "r") as stream:
+            config = yaml.safe_load(stream)
+            config = super().construct_float_from_scientific_notation(config)
+
+        assert (config and config['alg_name'] == 'MEMIT-FE') or print(f'MEMITFEHyperParams can not load from {hparams_name_or_path}, '
+                                                f'alg_name is {config["alg_name"]} ')
+        return cls(**config)

--- a/easyeditor/models/memit_FE/memit_FE_main.py
+++ b/easyeditor/models/memit_FE/memit_FE_main.py
@@ -1,0 +1,349 @@
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from ..rome.layer_stats import layer_stats
+from ...util import nethook
+from ...util.generate import generate_fast
+from ...util.globals import *
+
+from .compute_ks import compute_ks
+from .compute_z import compute_z, get_module_input_output_at_words, find_fact_lookup_idx
+from .memit_FE_hparams import MEMITFEHyperParams
+
+# Cache variable(s)
+CONTEXT_TEMPLATES_CACHE = None
+COV_CACHE = {}
+
+
+def apply_memit_FE_to_model(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    requests: List[Dict],
+    hparams: MEMITFEHyperParams,
+    copy=False,
+    return_orig_weights=False,
+    cache_template: Optional[str] = None,
+    keep_original_weight=False,
+    **kwargs
+) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
+    """
+    Returns a model with the desired changes.
+    :param copy: If true, will preserve the original model while creating a new one to edit.
+        Note that you are responsible for deallocating the new model's memory to avoid leaks.
+    :return: (1) the updated model, (2) an original copy of the weights that changed
+    """
+
+    weights_copy = {}
+    if copy:
+        model = deepcopy(model)
+
+    deltas = execute_memit(model, tok, requests, hparams, cache_template=cache_template)
+
+    with torch.no_grad():
+        for w_name, (key_mat, val_mat) in deltas.items():
+            key_mat, val_mat = key_mat.to(f"cuda:{hparams.device}"), val_mat.to(f"cuda:{hparams.device}")
+            upd_matrix = key_mat @ val_mat.T
+            w = nethook.get_parameter(model, w_name)
+            upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
+
+            if return_orig_weights and w_name not in weights_copy:
+                weights_copy[w_name] = w.detach().clone()
+            w[...] += upd_matrix.float()
+
+    print(f"New weights successfully inserted into {list(deltas.keys())}")
+
+    return model, weights_copy
+
+
+def execute_memit(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    requests: List[Dict],
+    hparams: MEMITFEHyperParams,
+    cache_template: Optional[str] = None,
+) -> Dict[str, Tuple[torch.Tensor]]:
+    """
+    Executes the MEMIT update algorithm for the specified update at the specified layer
+    Invariant: model at beginning of function == model at end of function
+    """
+
+    deltas = {}
+
+    # Update target and print info
+    requests = deepcopy(requests)
+    for i, request in enumerate(requests):
+        if request["target_new"][0] != " ":
+            # Space required for correct tokenization
+            requests[i]["target_new"] = " " + request["target_new"]
+
+        if '{}' not in request['prompt']:
+            assert request['subject'] in request['prompt'] or \
+                   print(f"Subject:{request['subject']} do not exist in prompt: {request['prompt']}")
+
+            requests[i]['prompt'] = requests[i]['prompt'].replace(requests[i]['subject'], '{}')
+
+    for request in requests[:10]:
+        print(
+            f"MEMIT request sample: "
+            f"[{request['prompt'].format(request['subject'])}] -> [{request['target_new']}]"
+        )
+
+    # Retrieve weights that user desires to change
+    weights = {
+        f"{hparams.rewrite_module_tmp.format(layer)}.weight": nethook.get_parameter(
+            model, f"{hparams.rewrite_module_tmp.format(layer)}.weight"
+        )
+        for layer in hparams.layers
+    }
+    # Save old weights for future restoration
+    weights_copy = {k: v.detach().clone() for k, v in weights.items()}
+
+    # Compute z for final layer
+    context_templates = get_context_templates(model, tok)
+    z_layers = hparams.layers # all 
+    z_list = {layer: [] for layer in z_layers}
+    zs = {layer: None for layer in z_layers}
+
+    for request in requests:
+        # Retrieve k/v pair if already stored in cache
+        need_compute = False
+        cached_for_request = {layer: False for layer in z_layers}
+
+        cur_z_list = {layer: None for layer in z_layers}
+        for layer in z_layers:
+            cache_fname = (
+                Path(
+                    str(cache_template).format(
+                        layer, hparams.clamp_norm_factor, request["case_id"]
+                    )
+                )
+                if cache_template is not None
+                else None
+            )
+            if (
+                cache_fname is not None  # Require cache template
+                and cache_fname.exists()  # Cache file must exist
+            ):
+                try:
+                    data = np.load(cache_fname)
+                    # z_list[layer].append(torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}"))
+                    cur_z_list[layer] = torch.from_numpy(data["v_star"]).to(f"cuda:{hparams.device}")
+                    cached_for_request[layer] = True
+                    print(f"Loaded k/v pair for layer {layer} from cache for request {request['case_id']}")
+                except Exception as e:
+                    print(f"Error reading cache file due to {e}. Recomputing...")
+                    need_compute = True
+            else:
+                need_compute = True
+            
+
+        # Compute k/v pair if not loaded from cache
+        if not need_compute:
+            for layer in z_layers:
+                z_list[layer].append(cur_z_list[layer])
+        else:
+            cur_z_list = compute_z(
+                model,
+                tok,
+                request,
+                hparams,
+                z_layers,
+                context_templates,
+            )
+
+            for layer in z_layers:
+                cur_z = cur_z_list[layer]
+                z_list[layer].append(cur_z)
+
+                cache_fname = (
+                    Path(
+                        str(cache_template).format(
+                            layer, hparams.clamp_norm_factor, request["case_id"]
+                        )
+                    )
+                    if cache_template is not None
+                    else None
+                )
+                if cache_fname is not None:
+                    cache_fname.parent.mkdir(exist_ok=True, parents=True)
+                    np.savez(
+                        cache_fname,
+                        **{
+                            "v_star": cur_z.detach().cpu().numpy(),
+                        },
+                    )
+                    print(f"Cached k/v pair at {cache_fname}")
+
+    zs = {layer: torch.stack(z_list[layer], dim=1) for layer in z_layers}
+
+    # Insert
+    for i, layer in enumerate(hparams.layers):
+        print(f"\n\nLAYER {layer}\n")
+
+        # Get current model activations
+        layer_ks = compute_ks(model, tok, requests, hparams, layer, context_templates).T
+        print(f"Writing {layer_ks.size(1)} key/value pair(s) into layer {layer}")
+
+        # Compute residual error
+        cur_zs = get_module_input_output_at_words(
+            model,
+            tok,
+            layer,
+            context_templates=[request["prompt"] for request in requests],
+            words=[request["subject"] for request in requests],
+            module_template=hparams.layer_module_tmp,
+            fact_token_strategy=hparams.fact_token,
+            track='out'
+        ).T
+        targets = zs[layer] - cur_zs
+        print("z error", torch.linalg.norm(targets, dim=0).mean())
+
+        repeat_factor = (layer_ks.size(1) // targets.size(1))
+        targets = targets.repeat_interleave(repeat_factor, dim=1)
+
+        # Load covariance matrix
+        force_recompute = False
+        # force_recompute = layer != hparams.layers[0]
+        cov = get_cov(
+            model,
+            tok,
+            hparams.rewrite_module_tmp.format(layer),
+            hparams.mom2_dataset,
+            hparams.mom2_n_samples
+            if not force_recompute
+            else hparams.mom2_n_samples // 10,
+            hparams.mom2_dtype,
+            force_recompute=force_recompute,
+            hparams=hparams
+        )
+
+        # Compute update in double precision
+        layer_ks, targets = (
+            layer_ks.double(),
+            targets.double(),
+        )
+
+        adj_k = torch.linalg.solve(
+            hparams.mom2_update_weight * cov.double() + layer_ks @ layer_ks.T,
+            layer_ks,
+        )
+        # resid = targets / (len(hparams.layers) - i)  # Distribute residual across layers
+        resid = targets  # Do not distribute residual across layers
+
+        upd_matrix = resid @ adj_k.T
+
+        # Adjust update matrix shape
+        weight_name = f"{hparams.rewrite_module_tmp.format(layer)}.weight"
+        upd_matrix = upd_matrix_match_shape(upd_matrix, weights[weight_name].shape)
+
+        print("orig norm", torch.linalg.norm(weights[weight_name]))
+        print("upd norm", torch.linalg.norm(upd_matrix))
+
+        # Update model weights and record desired changes in `delta` variable
+        with torch.no_grad():
+            weights[weight_name][...] = weights_copy[weight_name] + upd_matrix.float()
+            deltas[weight_name] = (
+                adj_k.detach().cpu(),
+                resid.detach().cpu(),
+            )
+
+        # Clear GPU memory
+        cov.cpu()
+        for x in [layer_ks, cur_zs, targets]:
+            x.cpu()
+            del x
+        torch.cuda.empty_cache()
+
+    # Restore state of original model
+    with torch.no_grad():
+        for k, v in weights.items():
+            v[...] = weights_copy[k]
+
+    print(f"Deltas successfully computed for {list(weights.keys())}")
+
+    return deltas
+
+
+def get_cov(
+    model: AutoModelForCausalLM,
+    tok: AutoTokenizer,
+    layer_name: str,
+    mom2_dataset: str,
+    mom2_n_samples: str,
+    mom2_dtype: str,
+    inv: bool = False,
+    force_recompute: bool = False,
+    hparams=None,
+) -> torch.Tensor:
+    """
+    Retrieves covariance statistics, then computes the algebraic inverse.
+    Caches result for future use.
+    """
+
+    model_name = model.config._name_or_path.replace("/", "_")
+    key = (model_name, layer_name)
+
+    print(f"Retrieving covariance statistics for {model_name} @ {layer_name}.")
+    if key not in COV_CACHE or force_recompute:
+        stat = layer_stats(
+            model,
+            tok,
+            layer_name,
+            hparams.stats_dir,
+            mom2_dataset,
+            to_collect=["mom2"],
+            sample_size=mom2_n_samples,
+            precision=mom2_dtype,
+            hparams=hparams,
+            force_recompute=force_recompute,
+        )
+        COV_CACHE[key] = stat.mom2.moment().float().to("cpu")
+
+    return (
+        torch.inverse(COV_CACHE[key].to(f"cuda:{hparams.device}")) if inv else COV_CACHE[key].to(f"cuda:{hparams.device}")
+    )
+
+
+def upd_matrix_match_shape(matrix: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    """
+    GPT-2 and GPT-J have transposed weight representations.
+    Returns a matrix that matches the desired shape, else raises a ValueError
+    """
+
+    if matrix.shape == shape:
+        return matrix
+    elif matrix.T.shape == shape:
+        return matrix.T
+    else:
+        raise ValueError(
+            "Update matrix computed by MEMIT does not match original weight shape. "
+            "Check for bugs in the code?"
+        )
+
+
+def get_context_templates(model, tok):
+    global CONTEXT_TEMPLATES_CACHE
+
+    if CONTEXT_TEMPLATES_CACHE is None:
+        CONTEXT_TEMPLATES_CACHE = [["{}"]] + [
+            [
+                f.replace("{", " ").replace("}", " ") + ". {}"
+                for f in generate_fast(
+                    model,
+                    tok,
+                    ["The", "Therefore", "Because", "I", "You"],
+                    n_gen_per_prompt=n_gen // 5,
+                    max_out_len=length,
+                )
+            ]
+            for length, n_gen in [(10, 5)]  # Be careful about changing this.
+        ]
+        print(f"Cached context templates {CONTEXT_TEMPLATES_CACHE}")
+
+    return CONTEXT_TEMPLATES_CACHE

--- a/easyeditor/util/alg_dict.py
+++ b/easyeditor/util/alg_dict.py
@@ -1,5 +1,6 @@
 from ..models.rome import ROMEHyperParams, apply_rome_to_model
 from ..models.memit import MEMITHyperParams, apply_memit_to_model
+from ..models.memit_FE import MEMITFEHyperParams, apply_memit_FE_to_model
 from ..models.kn import KNHyperParams, apply_kn_to_model
 from ..models.mend import MENDHyperParams, MendRewriteExecutor, MendMultimodalRewriteExecutor, MendPerRewriteExecutor
 from ..models.ft import FTHyperParams, apply_ft_to_model
@@ -28,6 +29,7 @@ from ..models.simie import SimIEHyperParams, apply_simie_to_model
 ALG_DICT = {
     'ROME': apply_rome_to_model,
     'MEMIT': apply_memit_to_model,
+    'MEMIT-FE': apply_memit_FE_to_model,
     "FT": apply_ft_to_model,
     "DINM": apply_dinm_to_model,
     'KN': apply_kn_to_model,

--- a/hparams/MEMIT-FE/README.md
+++ b/hparams/MEMIT-FE/README.md
@@ -1,0 +1,29 @@
+alg_name: "MEMIT-FE"
+model_name: THUDM/chatglm2-6b
+stats_dir: "./data/stats"
+device: 0
+layers: [13, 14, 15, 16, 17]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+#the place of token
+v_num_grad_steps: 25
+#the times of memit
+
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+
+rewrite_module_tmp: "transformer.encoder.layers.{}.mlp.dense_4h_to_h"
+layer_module_tmp: "transformer.encoder.layers.{}"
+mlp_module_tmp: "transformer.encoder.layers.{}.mlp"
+attn_module_tmp: "transformer.encoder.layers.{}.self_attention"
+ln_f_module: "transformer.encoder.final_layernorm"
+lm_head_module: "transformer.output_layer"
+#serach layer
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"

--- a/hparams/MEMIT-FE/baichuan-7b.yaml
+++ b/hparams/MEMIT-FE/baichuan-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "/mnt/xzk/Baichuan-7B"
+stats_dir: "/mnt/peng/EasyEdit/data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 31
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/chatglm2-6b.yaml
+++ b/hparams/MEMIT-FE/chatglm2-6b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: THUDM/chatglm2-6b
+stats_dir: "./data/stats"
+device: 0
+layers: [13, 14, 15, 16, 17]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "transformer.encoder.layers.{}.mlp.dense_4h_to_h"
+layer_module_tmp: "transformer.encoder.layers.{}"
+mlp_module_tmp: "transformer.encoder.layers.{}.mlp"
+attn_module_tmp: "transformer.encoder.layers.{}.self_attention"
+ln_f_module: "transformer.encoder.final_layernorm"
+lm_head_module: "transformer.output_layer"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/gpt-j-6B.yaml
+++ b/hparams/MEMIT-FE/gpt-j-6B.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/gpt-j-6B"
+stats_dir: "./data/stats"
+device: 3
+layers: [3, 4, 5, 6, 7, 8]
+clamp_norm_factor: 0.75
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 0.5
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "transformer.h.{}.mlp.fc_out"
+layer_module_tmp: "transformer.h.{}"
+mlp_module_tmp: "transformer.h.{}.mlp"
+attn_module_tmp: "transformer.h.{}.attn"
+ln_f_module: "transformer.ln_f"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/gpt2-xl.yaml
+++ b/hparams/MEMIT-FE/gpt2-xl.yaml
@@ -1,5 +1,5 @@
 alg_name: "MEMIT-FE"
-model_name: "/hkLIU/@Model-Edit/easyedit/hf_cache/hub/models--gpt2-xl/snapshots/15ea56dee5df4983c59b2538573817e1667135e2"
+model_name: "./hugging_cache/gpt2-xl"
 stats_dir: "./tmp/stats"
 device: 0
 layers: [13, 14, 15, 16, 17]

--- a/hparams/MEMIT-FE/gpt2-xl.yaml
+++ b/hparams/MEMIT-FE/gpt2-xl.yaml
@@ -6,13 +6,13 @@ layers: [13, 14, 15, 16, 17]
 clamp_norm_factor: 0.75
 layer_selection: "all"
 fact_token: "subject_last"
-v_num_grad_steps: 20
+v_num_grad_steps: 35
 v_lr: 5e-1
 v_loss_layer: 47
 v_weight_decay: 0.5
 kl_factor: 0.0625
 mom2_adjustment: true
-mom2_update_weight: 20000
+mom2_update_weight: 15000
 rewrite_module_tmp: "transformer.h.{}.mlp.c_proj"
 layer_module_tmp: "transformer.h.{}"
 mlp_module_tmp: "transformer.h.{}.mlp"

--- a/hparams/MEMIT-FE/gpt2-xl.yaml
+++ b/hparams/MEMIT-FE/gpt2-xl.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "/hkLIU/@Model-Edit/easyedit/hf_cache/hub/models--gpt2-xl/snapshots/15ea56dee5df4983c59b2538573817e1667135e2"
+stats_dir: "./tmp/stats"
+device: 0
+layers: [13, 14, 15, 16, 17]
+clamp_norm_factor: 0.75
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 20
+v_lr: 5e-1
+v_loss_layer: 47
+v_weight_decay: 0.5
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 20000
+rewrite_module_tmp: "transformer.h.{}.mlp.c_proj"
+layer_module_tmp: "transformer.h.{}"
+mlp_module_tmp: "transformer.h.{}.mlp"
+attn_module_tmp: "transformer.h.{}.attn"
+ln_f_module: "transformer.ln_f"
+lm_head_module: "transformer.wte"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/internlm-7b.yaml
+++ b/hparams/MEMIT-FE/internlm-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/internlm-7b"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 31
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/llama-7b.yaml
+++ b/hparams/MEMIT-FE/llama-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/llama-2-7b"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 31
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/llama3-8b.yaml
+++ b/hparams/MEMIT-FE/llama3-8b.yaml
@@ -1,5 +1,5 @@
 alg_name: "MEMIT-FE"
-model_name: "/hkLIU/@Model-Edit/easyedit/hf_cache/hub/models--meta-llama--Meta-Llama-3-8B-Instruct/snapshots/8afb486c1db24fe5011ec46dfbe5b5dccdb575c2"
+model_name: "./hugging_cache/llama3-8b-instruct"
 stats_dir: "./tmp/stats"
 device: 0
 layers: [4, 5, 6, 7, 8]

--- a/hparams/MEMIT-FE/llama3-8b.yaml
+++ b/hparams/MEMIT-FE/llama3-8b.yaml
@@ -1,6 +1,6 @@
 alg_name: "MEMIT-FE"
-model_name: "./hugging_cache/meta-llama/Meta-Llama-3-8B-Instruct"
-stats_dir: "./data/stats"
+model_name: "/hkLIU/@Model-Edit/easyedit/hf_cache/hub/models--meta-llama--Meta-Llama-3-8B-Instruct/snapshots/8afb486c1db24fe5011ec46dfbe5b5dccdb575c2"
+stats_dir: "./tmp/stats"
 device: 0
 layers: [4, 5, 6, 7, 8]
 clamp_norm_factor: 4

--- a/hparams/MEMIT-FE/llama3-8b.yaml
+++ b/hparams/MEMIT-FE/llama3-8b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/meta-llama/Meta-Llama-3-8B-Instruct"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 1e-1
+v_loss_layer: 31
+v_weight_decay: 5e-1
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/llama3.2-3b.yaml
+++ b/hparams/MEMIT-FE/llama3.2-3b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT"
+model_name: "/mnt/16t/share/llama-3.2-3b"
+stats_dir: "./data/stats"
+device: 1
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "model.embed_tokens"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/mistral-7b.yaml
+++ b/hparams/MEMIT-FE/mistral-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: 'MEMIT-FE'
+model_name: './hugging_cache/Mistral-7B-v0.1'
+stats_dir: './data/stats'
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: 'all'
+fact_token: 'subject_last'
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 31
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: 'model.layers.{}.mlp.down_proj'
+layer_module_tmp: 'model.layers.{}'
+mlp_module_tmp: 'model.layers.{}.mlp'
+attn_module_tmp: 'model.layers.{}.self_attn'
+ln_f_module: 'model.norm'
+lm_head_module: 'lm_head'
+mom2_dataset: 'wikipedia'
+mom2_n_samples: 100000
+mom2_dtype: 'float32'
+model_parallel: false

--- a/hparams/MEMIT-FE/qwen-7b.yaml
+++ b/hparams/MEMIT-FE/qwen-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/qwen-7b"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 0.75
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 31
+v_weight_decay: 0.5
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "transformer.h.{}.mlp.c_proj"
+layer_module_tmp: "transformer.h.{}"
+mlp_module_tmp: "transformer.h.{}.mlp"
+attn_module_tmp: "transformer.h.{}.attn"
+ln_f_module: "transformer.ln_f"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false

--- a/hparams/MEMIT-FE/qwen2-7b.yaml
+++ b/hparams/MEMIT-FE/qwen2-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/Qwen2-7B"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: False

--- a/hparams/MEMIT-FE/qwen2.5-7b.yaml
+++ b/hparams/MEMIT-FE/qwen2.5-7b.yaml
@@ -1,0 +1,25 @@
+alg_name: "MEMIT-FE"
+model_name: "./hugging_cache/Qwen2.5-7B"
+stats_dir: "./data/stats"
+device: 5
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: False


### PR DESCRIPTION
# Description
This PR introduces forward-propagation target construction method, a new method for multi-layer LLM parameter editing, implemented according to our paper accepted to ICML 2026: **_From Backward Spreading to Forward Replay: Revisiting Target Construction in LLM Parameter Editing_** (https://arxiv.org/abs/2605.00358)

## Background & Proposed Method
Locate-then-edit frameworks that distribute updates across multiple layers (e.g., MEMIT) conventionally compute an ideal target hidden state at the last anchor layer and distribute this vector to preceding layers via backward spreading.

As systematically investigated and proven in our paper, backward spreading introduces optimization mismatches and layer-wise target incompatibility because it forces vectors backward through representations designed strictly for forward computation.

We propose a simple, elegant alternative that includes 2 steps to construct multi-layer targets:
1. First-layer Optimization: Instead of optimizing the target at the final editing layer, we optimize the target at the first anchor layer using the same method.
2. Forward Propagation: The optimized hidden state for the first anchor layer is directly injected back into the LLM's native transformer blocks. We then execute a partial forward pass through the remaining designated editing layers, extracting the resulting hidden states at each layer to serve as their respective targets.

This new method maintains the almost same computational complexity while providing cleaner and more accurate targets. It acts as a modular upgrade without interfering with the downstream weight update solvers (e.g., closed-form solution calculation in MEMIT).

## Key Features of the Code
The implementation introduces MEMIT-FE as an independent method under easyeditor/models/memit_FE, adapting carefully from the native memit implementation to maximize code reuse and prevent regressions:
 - _compute_ks.py_: Utilize the same code as classic MEMIT.
 - _compute_z.py_: Adapted from MEMIT's target calculation block:
     - The internal function __direct_compute_z()_ remains identical to the original _compute_z()_ in MEMIT to preserve baseline alignment.
     - The top-level _compute_z()_ function is newly added to handle the first-layer optimization pass and the subsequent forward propagation pass, cleanly returning a comprehensive target dictionary across all layers.
     - The remaining functions remains identical to the original code in MEMIT.
 - _memit_FE_hparams.py_: Adapt from _memit_hparams.py_ but change the class name and name in assertion.
 - _memit_FE_main.py_: Adapt from _memit_main.py_. It updates how compute_z is unpacked to properly ingest the new multi-layer targets dictionary. Crucially, when computing residuals in the main loop, it removes the manual "distribute residual across layers" routine, as the forward replay mechanism already provides structurally sound targets for every layer.

## Details of the Changes
This PR elevates MEMIT-FE to a first-class citizen inside the EasyEdit framework through the following points of integration:

**Major additions and integrations:**

* Added the MEMIT-FE algorithm implementation, including its main logic (`memit_FE_main.py`), hyperparameter definitions (`memit_FE_hparams.py`), and supporting computation modules (`compute_z.py` & `compute_ks.py`). 
* Registered MEMIT-FE in the batch editor (`BatchEditor` enum and `is_batchable_method`) and in the algorithm dictionary (`ALG_DICT`) for selection and execution.
* Imported MEMIT-FE modules in the package initialization to ensure discoverability and proper integration.

**Configuration and documentation:**

* Added hyperparameter YAML files for MEMIT-FE for multiple models (e.g., GPT-2 XL, GPT-J-6B, LLAMA3-8B) and a README with example configuration. 
* The structure and types of hyperparameters match classic MEMIT exactly to maintain user familiarity. For example, setting `layers: [4, 5, 6, 7, 8]` tells the framework to edit layers 4 through 8, where layer 4 is automatically treated as the first anchor layer for optimization, and layers 5–8 receive the subsequent forward-propagated targets.

## Note
It is worth noting that Forward Replay is fundamentally a modular upgrade to the target construction phase of locate-then-edit (LTE) frameworks. Because it works independently of the underlying weight projection or update mechanics, this target collection logic can easily be scaled or extended to other prominent multi-layer editing pipelines within EasyEdit (e.g., AlphaEdit).

We highly welcome community contributions, discussion, or future PRs extending this forward propagation blueprint to other editing algorithms!
