### PR TITLE
Fix sharded-model device handling for hook editors

### DIFF
--- a/easyeditor/models/SPHERE/SPHERE_main.py
+++ b/easyeditor/models/SPHERE/SPHERE_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -89,10 +89,9 @@ def apply_SPHERE_to_model(
     deltas = execute_AlphaEdit(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
-        device = normalize_device(getattr(hparams, "device", None))
         for w_name, upd_m in deltas.items():
-            upd_matrix = upd_m.to(device)
             w = nethook.get_parameter(model, w_name)
+            upd_matrix = upd_m.to(device=w.device, dtype=w.dtype)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
@@ -177,6 +176,8 @@ def execute_AlphaEdit(
     # Compute z for final layer
     context_templates = get_context_templates(model, tok)
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
 
     for request in requests:
@@ -197,7 +198,7 @@ def execute_AlphaEdit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -244,6 +245,7 @@ def execute_AlphaEdit(
             module_template=hparams.layer_module_tmp,
             fact_token_strategy=hparams.fact_token,
         )[1].T
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 

--- a/easyeditor/models/SPHERE/compute_z.py
+++ b/easyeditor/models/SPHERE/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .SPHERE_hparams import SPHEREHyperParams
 
@@ -36,6 +36,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -82,9 +84,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -93,8 +95,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -104,9 +107,9 @@ def compute_z(
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -151,7 +154,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -191,7 +195,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/alphaedit/AlphaEdit_main.py
+++ b/easyeditor/models/alphaedit/AlphaEdit_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -88,10 +88,9 @@ def apply_AlphaEdit_to_model(
     deltas = execute_AlphaEdit(model, tok, requests, hparams, cache_template=cache_template)
 
     with torch.no_grad():
-        device = normalize_device(getattr(hparams, "device", None))
         for w_name, upd_m in deltas.items():
-            upd_matrix = upd_m.to(device)
             w = nethook.get_parameter(model, w_name)
+            upd_matrix = upd_m.to(device=w.device, dtype=w.dtype)
             upd_matrix = upd_matrix_match_shape(upd_matrix, w.shape)
 
             if return_orig_weights and w_name not in weights_copy:
@@ -147,6 +146,8 @@ def execute_AlphaEdit(
     # Compute z for final layer
     context_templates = get_context_templates(model, tok)
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
 
     for request in requests:
@@ -167,7 +168,7 @@ def execute_AlphaEdit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -214,6 +215,7 @@ def execute_AlphaEdit(
             module_template=hparams.layer_module_tmp,
             fact_token_strategy=hparams.fact_token,
         )[1].T
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 

--- a/easyeditor/models/alphaedit/compute_z.py
+++ b/easyeditor/models/alphaedit/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .AlphaEdit_hparams import AlphaEditHyperParams
 
@@ -36,6 +36,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -82,9 +84,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -93,8 +95,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -104,9 +107,9 @@ def compute_z(
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -151,7 +154,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -191,7 +195,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/core/compute_z.py
+++ b/easyeditor/models/core/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .core_hparams import COREHyperParams
 
@@ -46,6 +46,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -91,9 +93,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -102,8 +104,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -114,9 +117,9 @@ def compute_z(
             for i, idx in enumerate(lookup_idxs):
 
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -175,7 +178,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -246,7 +250,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/core/core_main.py
+++ b/easyeditor/models/core/core_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -110,6 +110,8 @@ def execute_core(
     # Compute z for final layer
     context_templates = get_context_templates(model = model, tok = tok, length = hparams.ctx_len, ctx_top_k = hparams.ctx_top_k, ctx_num=hparams.ctx_num) 
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
 
     for request in requests:
@@ -130,7 +132,7 @@ def execute_core(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -178,6 +180,7 @@ def execute_core(
             fact_token_strategy=hparams.fact_token,
             track='out'
         ).T
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 

--- a/easyeditor/models/eamet/compute_z.py
+++ b/easyeditor/models/eamet/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 import random
 import copy
 import time
@@ -69,6 +69,8 @@ def compute_z(
     ##############################################################################
 
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
     target_ids = tok(request["target_new"]["str"], return_tensors="pt").to(device)["input_ids"][0]
 
     print(f"DEBUG INFO:target_ids:{target_ids}")
@@ -143,14 +145,15 @@ def compute_z(
     
     # Finalize rewrite and loss layers
     loss_layer = max(hparams.v_loss_layer, layer)
-    delta = torch.zeros((model.config.hidden_size, ), device=device, requires_grad=True)
+    delta = torch.zeros((model.config.hidden_size, ), device=rewrite_device, requires_grad=True)
     target_init, kl_distr_init, target_constrain = None, None, None
 
     ### nonlocal helps to modify parameter from outer function
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init, target_constrain, delta
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             if target_init is None:
                 print("Recording initial value of v*")
                 target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
@@ -175,7 +178,7 @@ def compute_z(
                     
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                hidden_state[i, idx, :] += delta
+                hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -223,13 +226,14 @@ def compute_z(
             : len(rewriting_prompts)
         ]
 
-        after_mult = ln_f(full_repr) @ lm_w + lm_b
+        full_repr = ln_f(full_repr)
+        after_mult = full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device)
         log_probs = torch.log_softmax(after_mult, dim=2)
 
         loss = torch.gather(
             log_probs,
             2,
-            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2),
+            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2).to(log_probs.device),
         ).squeeze(2) # use gather to pick desired token from vocabulary
         mask = (rewriting_targets != -100).float()
 
@@ -254,7 +258,7 @@ def compute_z(
                 end_time = time.time()
                 print(f"time cost when compute cs structure:{end_time - start_time}")
 
-        nll_loss_each = -(loss * mask).sum(1) / opt_target_ids.size(0)
+        nll_loss_each = -(loss * mask.to(loss.device)).sum(1) / opt_target_ids.size(0)
         nll_loss = nll_loss_each.mean()
 
         kl_loss = hparams.kl_factor * torch.nn.functional.kl_div(
@@ -270,7 +274,17 @@ def compute_z(
         else:
             raise ValueError(f"weight_decay_method={hparams.weight_decay_method} not recognized")
 
-        loss = nll_loss + kl_loss + weight_decay + collision_loss + mse_loss
+        if torch.is_tensor(collision_loss):
+            collision_loss = collision_loss.to(nll_loss.device)
+        if torch.is_tensor(mse_loss):
+            mse_loss = mse_loss.to(nll_loss.device)
+        loss = (
+            nll_loss
+            + kl_loss.to(nll_loss.device)
+            + weight_decay.to(nll_loss.device)
+            + collision_loss
+            + mse_loss
+        )
 
         if loss < 1e-2 or it==0:
             if isinstance(collision_loss, int):
@@ -336,7 +350,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
  
-    target = target_init + delta    
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/eamet/eamet_main.py
+++ b/easyeditor/models/eamet/eamet_main.py
@@ -15,7 +15,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast, generate_standard
 from ...util.globals import *
 
@@ -121,6 +121,8 @@ def execute_eamet(
     # Compute z for final layer
 
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
     delta_list = []
     context_templates = get_context_templates(model, tok)
@@ -171,8 +173,8 @@ def execute_eamet(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
-                delta_list.append(torch.from_numpy(data["delta"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
+                delta_list.append(torch.from_numpy(data["delta"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -192,8 +194,8 @@ def execute_eamet(
                 layer_ks_norm=layer_ks_norm[re_id]
             )
 
-            z_list.append(opt_zs.to(device))
-            delta_list.append(delta.to(device))
+            z_list.append(opt_zs.to(z_device))
+            delta_list.append(delta.to(z_device))
             if cache_fname is not None:
                 try:
                     cache_fname.parent.mkdir(exist_ok=True, parents=True)
@@ -238,6 +240,7 @@ def execute_eamet(
         )[1].T #0 for the module input before layer_module, 1 for the output after layer_module
         cur_zs_list.append(cur_zs)
         cur_zs=torch.cat(cur_zs_list,dim=1)
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs # targets to be distributed across layers
 
         # after transpose, layer_ks.size(1) and targets.size(1) means the number

--- a/easyeditor/models/emmet/compute_z.py
+++ b/easyeditor/models/emmet/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .emmet_hparams import EMMETHyperParams
 
@@ -36,6 +36,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -81,9 +83,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -92,8 +94,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -104,9 +107,9 @@ def compute_z(
             for i, idx in enumerate(lookup_idxs):
 
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -151,7 +154,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -191,7 +195,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/emmet/emmet_main.py
+++ b/easyeditor/models/emmet/emmet_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -113,6 +113,8 @@ def execute_emmet(
     # Compute z for final layer
     context_templates = get_context_templates(model, tok)
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
 
     for request in requests:
@@ -133,7 +135,7 @@ def execute_emmet(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -181,6 +183,7 @@ def execute_emmet(
             fact_token_strategy=hparams.fact_token,
             track='out'
         ).T
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 

--- a/easyeditor/models/memit/compute_z.py
+++ b/easyeditor/models/memit/compute_z.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .memit_hparams import MEMITHyperParams
 
@@ -36,6 +36,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -81,9 +83,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -92,8 +94,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             layer_output = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=layer_output.device, dtype=layer_output.dtype)
 
             # Store initial value of the vector of interest
             if target_init is None:
@@ -105,9 +108,9 @@ def compute_z(
             for i, idx in enumerate(lookup_idxs):
 
                 if len(lookup_idxs)!=layer_output.shape[0]:
-                    layer_output[idx, i, :] += delta
+                    layer_output[idx, i, :] += delta_for_hidden
                 else:
-                    layer_output[i, idx, :] += delta
+                    layer_output[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, layer_output)
 
@@ -153,7 +156,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr = output[:len(rewriting_prompts)]
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -193,7 +197,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/memit/memit_main.py
+++ b/easyeditor/models/memit/memit_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -110,6 +110,8 @@ def execute_memit(
     # Compute z for final layer
     context_templates = get_context_templates(model, tok)
     z_layer = hparams.layers[-1]
+    z_module_name = hparams.layer_module_tmp.format(z_layer)
+    z_device = get_module_device(nethook.get_module(model, z_module_name), device)
     z_list = []
 
     for request in requests:
@@ -130,7 +132,7 @@ def execute_memit(
         ):
             try:
                 data = np.load(cache_fname)
-                z_list.append(torch.from_numpy(data["v_star"]).to(device))
+                z_list.append(torch.from_numpy(data["v_star"]).to(z_device))
                 data_loaded = True
             except Exception as e:
                 print(f"Error reading cache file due to {e}. Recomputing...")
@@ -178,6 +180,7 @@ def execute_memit(
             fact_token_strategy=hparams.fact_token,
             track='out'
         ).T
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 

--- a/easyeditor/models/pmet/compute_zs.py
+++ b/easyeditor/models/pmet/compute_zs.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .pmet_hparams import PMETHyperParams
 
@@ -41,6 +41,10 @@ def compute_zs(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    mlp_module_name = hparams.mlp_module_tmp.format(layer)
+    attn_module_name = hparams.attn_module_tmp.format(layer)
+    mlp_device = get_module_device(nethook.get_module(model, mlp_module_name), device)
+    attn_device = get_module_device(nethook.get_module(model, attn_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -85,11 +89,11 @@ def compute_zs(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
-        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
-        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta_attn = torch.zeros((model.config.n_embd,), requires_grad=True, device=attn_device)
+        delta_mlp = torch.zeros((model.config.n_embd,), requires_grad=True, device=mlp_device)
     elif hasattr(model.config, "hidden_size"):
-        delta_attn = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
-        delta_mlp = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta_attn = torch.zeros((model.config.hidden_size,), requires_grad=True, device=attn_device)
+        delta_mlp = torch.zeros((model.config.hidden_size,), requires_grad=True, device=mlp_device)
     else:
         raise NotImplementedError
     target_init_attn, target_init_mlp, kl_distr_init = None, None, None
@@ -98,8 +102,9 @@ def compute_zs(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init_attn, target_init_mlp
 
-        if cur_layer == hparams.mlp_module_tmp.format(layer):
+        if cur_layer == mlp_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta_mlp.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init_mlp is None:
                 print("Recording initial value of v* in mlp")
@@ -108,10 +113,11 @@ def compute_zs(
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                hidden_state[i, idx, :] += delta_mlp
+                hidden_state[i, idx, :] += delta_for_hidden
             return nethook.replace_hidden_state(cur_out, hidden_state)
-        if cur_layer == hparams.attn_module_tmp.format(layer):
+        if cur_layer == attn_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta_attn.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init_attn is None:
                 print("Recording initial value of v* in attn")
@@ -120,7 +126,7 @@ def compute_zs(
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                hidden_state[i, idx, :] += delta_attn
+                hidden_state[i, idx, :] += delta_for_hidden
             return nethook.replace_hidden_state(cur_out, hidden_state)
         return cur_out
 
@@ -163,26 +169,30 @@ def compute_zs(
         full_repr = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)[
             : len(rewriting_prompts)
         ]
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w + lm_b, dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
-            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2),
+            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2).to(log_probs.device),
         ).squeeze(2)
         mask = (rewriting_targets != -100).float()
         max_probs = torch.max(log_probs, dim = 2)[0]
-        max_prob = torch.exp((max_probs * mask).sum(1) / target_ids.size(0)).mean().item()
+        max_prob = torch.exp((max_probs * mask.to(max_probs.device)).sum(1) / target_ids.size(0)).mean().item()
         # Aggregate total losses
-        nll_loss_each = -(loss * mask).sum(1) / target_ids.size(0)
+        nll_loss_each = -(loss * mask.to(loss.device)).sum(1) / target_ids.size(0)
         nll_loss = nll_loss_factor * nll_loss_each.mean()
         kl_loss = kl_factor * torch.nn.functional.kl_div(
             kl_distr_init, kl_log_probs, log_target=True, reduction="batchmean"
         )
+        mlp_weight_decay = torch.norm(delta_mlp) / torch.norm(target_init_mlp) ** 2
+        attn_weight_decay = torch.norm(delta_attn) / torch.norm(target_init_attn) ** 2
         weight_decay = hparams.v_weight_decay * (
-            torch.norm(delta_mlp) / torch.norm(target_init_mlp) ** 2 + torch.norm(delta_attn) / torch.norm(target_init_attn) ** 2
+            mlp_weight_decay
+            + attn_weight_decay.to(device=mlp_weight_decay.device)
         )
         # weight_decay = hparams.v_weight_decay * torch.norm(delta) ** 2
-        loss = nll_loss + kl_loss + weight_decay
+        loss = nll_loss + kl_loss.to(nll_loss.device) + weight_decay.to(nll_loss.device)
         prob = torch.exp(-nll_loss_each).mean().item()
         print(
             f"loss {np.round(loss.item(), 3)} = {np.round(nll_loss.item(), 3)} + {np.round(kl_loss.item(), 3)} + {np.round(weight_decay.item(), 3)} "
@@ -216,8 +226,8 @@ def compute_zs(
             with torch.no_grad():
                 delta_attn[...] = delta_attn * max_norm / delta_attn.norm()
 
-    target_attn = target_init_attn + delta_attn
-    target_mlp = target_init_mlp + delta_mlp
+    target_attn = target_init_attn + delta_attn.to(device=target_init_attn.device, dtype=target_init_attn.dtype)
+    target_mlp = target_init_mlp + delta_mlp.to(device=target_init_mlp.device, dtype=target_init_mlp.dtype)
     print(
         f"[ATTN]: Init norm {target_init_attn.norm()} | Delta norm {delta_attn.norm()} | Target norm {target_attn.norm()}",
         f"[MLP]: Init norm {target_init_mlp.norm()} | Delta norm {delta_mlp.norm()} | Target norm {target_mlp.norm()}",
@@ -251,6 +261,8 @@ def compute_z(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.mlp_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok(request["target_new"], return_tensors="pt").to(device)[
@@ -296,9 +308,9 @@ def compute_z(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, "hidden_size"):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init, kl_distr_init = None, None
@@ -307,8 +319,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
 
-        if cur_layer == hparams.mlp_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -317,7 +330,7 @@ def compute_z(
 
             # Add intervened delta
             for i, idx in enumerate(lookup_idxs):
-                hidden_state[i, idx, :] += delta
+                hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -361,17 +374,18 @@ def compute_z(
         full_repr = nethook.get_hidden_state(tr[hparams.layer_module_tmp.format(loss_layer)].output)[
             : len(rewriting_prompts)
         ]
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w + lm_b, dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
-            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2),
+            torch.where(rewriting_targets != -100, rewriting_targets, 0).unsqueeze(2).to(log_probs.device),
         ).squeeze(2)
         mask = (rewriting_targets != -100).float()
         max_probs = torch.max(log_probs, dim = 2)[0]
-        max_prob = torch.exp((max_probs * mask).sum(1) / target_ids.size(0)).mean().item()
+        max_prob = torch.exp((max_probs * mask.to(max_probs.device)).sum(1) / target_ids.size(0)).mean().item()
         # Aggregate total losses
-        nll_loss_each = -(loss * mask).sum(1) / target_ids.size(0)
+        nll_loss_each = -(loss * mask.to(loss.device)).sum(1) / target_ids.size(0)
         nll_loss = nll_loss_factor * nll_loss_each.mean()
         kl_loss = hparams.kl_factor * torch.nn.functional.kl_div(
             kl_distr_init, kl_log_probs, log_target=True, reduction="batchmean"
@@ -380,7 +394,7 @@ def compute_z(
             torch.norm(delta) / torch.norm(target_init) ** 2
         )
         # weight_decay = hparams.v_weight_decay * torch.norm(delta) ** 2
-        loss = nll_loss + kl_loss + weight_decay
+        loss = nll_loss + kl_loss.to(nll_loss.device) + weight_decay.to(nll_loss.device)
         prob = torch.exp(-nll_loss_each).mean().item()
         print(
             f"loss {np.round(loss.item(), 3)} = {np.round(nll_loss.item(), 3)} + {np.round(kl_loss.item(), 3)} + {np.round(weight_decay.item(), 3)} "
@@ -409,7 +423,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
         f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/pmet/pmet_main.py
+++ b/easyeditor/models/pmet/pmet_main.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome.layer_stats import layer_stats
 from ...util import nethook
-from ...util.device import copy_to_param, normalize_device
+from ...util.device import copy_to_param, get_module_device, normalize_device
 from ...util.generate import generate_fast
 from ...util.globals import *
 
@@ -118,6 +118,10 @@ def execute_pmet(
         # Retrieve k/v pair if already stored in cache
         for rewrite_module_name in rewrite_module_names:
             block_name = "attn" if "attn" in rewrite_module_name else "mlp"
+            rewrite_device = get_module_device(
+                nethook.get_module(model, rewrite_module_name.format(z_layer)),
+                device,
+            )
             cache_fname = (
                 Path(
                     str(cache_template).format(
@@ -134,7 +138,7 @@ def execute_pmet(
             ):
                 try:
                     data = np.load(cache_fname)
-                    z_list[rewrite_module_name].append(torch.from_numpy(data["v_star"]).to(device))
+                    z_list[rewrite_module_name].append(torch.from_numpy(data["v_star"]).to(rewrite_device))
                     data_loaded = True
                 except Exception as e:
                     print(f"Error reading cache file due to {e}. Recomputing...")
@@ -232,7 +236,11 @@ def execute_pmet(
                 module_template=rewrite_module_name,
                 fact_token_strategy=hparams.fact_token,
             )[1].T
-            targets = z_list[rewrite_module_name]  - cur_zs #z_i - h_i^L
+            cur_zs = cur_zs.to(
+                device=z_list[rewrite_module_name].device,
+                dtype=z_list[rewrite_module_name].dtype,
+            )
+            targets = z_list[rewrite_module_name] - cur_zs #z_i - h_i^L
             layer_ks, targets = (
                 layers_ks[rewrite_module_name].T.double().to(device),
                 targets.double().to(device)

--- a/easyeditor/models/r_rome/compute_v.py
+++ b/easyeditor/models/r_rome/compute_v.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .r_rome_hparams import R_ROMEHyperParams
 
@@ -28,6 +28,8 @@ def compute_v(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.mlp_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok(request["target_new"], return_tensors="pt").to(device)["input_ids"][0]
@@ -85,21 +87,22 @@ def compute_v(
     # target token to be predicted at the final layer.
     if hasattr(model.config, "n_embd"):
         delta = torch.zeros(
-            (model.config.n_embd,), requires_grad=True, device=device
+            (model.config.n_embd,), requires_grad=True, device=rewrite_device
         )
     else:
         delta = torch.zeros(
             (model.config.hidden_size,),
             requires_grad=True,
-            device=device,
+            device=rewrite_device,
         )
     target_init, kl_distr_init = None, None
 
     # Inserts new "delta" variable at the appropriate part of the computation
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
-        if cur_layer == hparams.mlp_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -108,9 +111,9 @@ def compute_v(
 
             for i, idx in enumerate(lookup_idxs):
                 if len(lookup_idxs) != len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -169,7 +172,7 @@ def compute_v(
             torch.norm(delta) / torch.norm(target_init) ** 2
         )
         # weight_decay = hparams.v_weight_decay * torch.norm(delta) ** 2
-        loss = nll_loss + kl_loss + weight_decay
+        loss = nll_loss + kl_loss + weight_decay.to(nll_loss.device)
         print(
             f"loss {np.round(loss.item(), 3)} = {np.round(nll_loss.item(), 3)} + {np.round(kl_loss.item(), 3)} + {np.round(weight_decay.item(), 3)} "
             f"avg prob of [{request['target_new']}] "
@@ -212,7 +215,7 @@ def compute_v(
         cur_output = torch.stack(cur_outputs).mean(0)
 
         # target_init is v*, based on output from random prefix computations
-        target = target_init + delta.to(target_init.dtype)
+        target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     else:
         # Original ROME code
         # Retrieve cur_input, the current input to the 2nd MLP layer, and
@@ -228,9 +231,11 @@ def compute_v(
         )
 
         # cur_output is v, based on output from prompt-only computations
-        target = cur_output + delta.to(target_init.dtype)
+        target = cur_output + delta.to(device=cur_output.device, dtype=cur_output.dtype)
 
     # Solving the linear system to compute the right vector
+    left_vector = left_vector.to(device=cur_input.device, dtype=cur_input.dtype)
+    target = target.to(device=cur_output.device, dtype=cur_output.dtype)
     right_vector = (target - cur_output) / torch.dot(cur_input, left_vector)
     print(f"Delta norm: {(target - cur_output).norm().item()}")
     print(

--- a/easyeditor/models/rome/compute_v.py
+++ b/easyeditor/models/rome/compute_v.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from ..rome import repr_tools
 from ...util import nethook
-from ...util.device import normalize_device
+from ...util.device import get_module_device, normalize_device
 
 from .rome_hparams import ROMEHyperParams
 
@@ -28,6 +28,8 @@ def compute_v(
 
     print("Computing right vector (v)")
     device = normalize_device(getattr(hparams, "device", None))
+    rewrite_module_name = hparams.mlp_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok.encode(request["target_new"], return_tensors="pt", add_special_tokens=False).to(device)[0]
@@ -76,16 +78,17 @@ def compute_v(
     # rewrite layer, i.e. hypothesized fact lookup location, will induce the
     # target token to be predicted at the final layer.
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     else:
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     target_init, kl_distr_init = None, None
 
     # Inserts new "delta" variable at the appropriate part of the computation
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init
-        if cur_layer == hparams.mlp_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             # Store initial value of the vector of interest
             if target_init is None:
                 print("Recording initial value of v*")
@@ -94,9 +97,9 @@ def compute_v(
                 
             for i, idx in enumerate(lookup_idxs):
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -155,7 +158,7 @@ def compute_v(
             torch.norm(delta) / torch.norm(target_init) ** 2
         )
         # weight_decay = hparams.v_weight_decay * torch.norm(delta) ** 2
-        loss = nll_loss + kl_loss + weight_decay
+        loss = nll_loss + kl_loss + weight_decay.to(nll_loss.device)
         print(
             f"loss {np.round(loss.item(), 3)} = {np.round(nll_loss.item(), 3)} + {np.round(kl_loss.item(), 3)} + {np.round(weight_decay.item(), 3)} "
             f"avg prob of [{request['target_new']}] "
@@ -177,7 +180,7 @@ def compute_v(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta.to(target_init.dtype)
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
 
     # Retrieve cur_input, the current input to the 2nd MLP layer, and
     # cur_output, the original output of the 2nd MLP layer.
@@ -192,6 +195,8 @@ def compute_v(
     )
 
     # Solving the linear system to compute the right vector
+    left_vector = left_vector.to(device=cur_input.device, dtype=cur_input.dtype)
+    target = target.to(device=cur_output.device, dtype=cur_output.dtype)
     right_vector = (target - cur_output) / torch.dot(cur_input, left_vector)
     print(f"Delta norm: {(target - cur_output).norm().item()}")
     print(

--- a/easyeditor/models/unke/compute_z.py
+++ b/easyeditor/models/unke/compute_z.py
@@ -4,7 +4,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from .unke_hparams import unkeHyperParams
 from ...util import nethook
-from ...util.device import get_model_device
+from ...util.device import get_model_device, get_module_device
 
 
 
@@ -32,6 +32,8 @@ def compute_z(
 
     #print("Computing right vector (v)")
     device = get_model_device(model, fallback=getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok(data["answer"], return_tensors="pt").to(device)[
@@ -64,9 +66,9 @@ def compute_z(
     loss_layer = max(hparams.v_loss_layer, layer)
     
     if hasattr(model.config, 'n_embd'):
-        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
     elif hasattr(model.config, 'hidden_size'):
-        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+        delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
     else:
         raise NotImplementedError
     target_init = None
@@ -75,8 +77,9 @@ def compute_z(
     def edit_output_fn(cur_out, cur_layer):
         nonlocal target_init  
 
-        if cur_layer == hparams.layer_module_tmp.format(layer):
+        if cur_layer == rewrite_module_name:
             hidden_state = nethook.get_hidden_state(cur_out)
+            delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
             
             if target_init is None:
                
@@ -86,9 +89,9 @@ def compute_z(
             for i, idx in enumerate(lookup_idxs):
                 
                 if len(lookup_idxs)!=len(hidden_state):
-                    hidden_state[idx, i, :] += delta
+                    hidden_state[idx, i, :] += delta_for_hidden
                 else:
-                    hidden_state[i, idx, :] += delta
+                    hidden_state[i, idx, :] += delta_for_hidden
 
             return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -123,7 +126,8 @@ def compute_z(
             output=torch.transpose(output, 0, 1)
         full_repr =  output
 
-        log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+        full_repr = ln_f(full_repr)
+        log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
         loss = torch.gather(
             log_probs,
             2,
@@ -161,7 +165,7 @@ def compute_z(
             with torch.no_grad():
                 delta[...] = delta * max_norm / delta.norm()
 
-    target = target_init + delta  
+    target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
     print(
        f"Init norm {target_init.norm()} | Delta norm {delta.norm()} | Target norm {target.norm()}"
     )

--- a/easyeditor/models/unke/unke_main.py
+++ b/easyeditor/models/unke/unke_main.py
@@ -125,6 +125,7 @@ def apply_unke_to_model(
         cur_zs,idxs = compute_ks(model, tok,batch_question, hparams, z_layer)
         
         
+        cur_zs = cur_zs.to(device=zs.device, dtype=zs.dtype)
         targets = zs - cur_zs 
         print("z error", torch.linalg.norm(targets, dim=0).mean())
 
@@ -166,7 +167,7 @@ def apply_unke_to_model(
         
         for i in range(len(idxs)):
             
-            layer_out_ks[i,idxs[i]]+=resid[i]
+            layer_out_ks[i,idxs[i]]+=resid[i].to(device=layer_out_ks.device, dtype=layer_out_ks.dtype)
         
         # get_qwen2_causal_mask
         # llama2

--- a/easyeditor/models/unke_ARE/compute_z.py
+++ b/easyeditor/models/unke_ARE/compute_z.py
@@ -4,7 +4,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from .unke_ARE_hparams import unkeAREHyperParams
 from ...util import nethook
-from ...util.device import get_model_device
+from ...util.device import get_model_device, get_module_device
 import nltk
 
 
@@ -32,6 +32,8 @@ def compute_z(
 
     #print("Computing right vector (v)")
     device = get_model_device(model, fallback=getattr(hparams, "device", None))
+    rewrite_module_name = hparams.layer_module_tmp.format(layer)
+    rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
 
     # Tokenize target into list of int token IDs
     target_ids = tok(data["answer"], return_tensors="pt").to(device)[
@@ -95,9 +97,9 @@ def compute_z(
         loss_layer = max(hparams.v_loss_layer, layer)
     
         if hasattr(model.config, 'n_embd'):
-            delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=device)
+            delta = torch.zeros((model.config.n_embd,), requires_grad=True, device=rewrite_device)
         elif hasattr(model.config, 'hidden_size'):
-            delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=device)
+            delta = torch.zeros((model.config.hidden_size,), requires_grad=True, device=rewrite_device)
         else:
             raise NotImplementedError
         target_init = None
@@ -105,25 +107,27 @@ def compute_z(
         def edit_output_fn(cur_out, cur_layer):
             nonlocal target_init  
 
-            if cur_layer == hparams.layer_module_tmp.format(layer):
+            if cur_layer == rewrite_module_name:
                 hidden_state = nethook.get_hidden_state(cur_out)
+                delta_for_hidden = delta.to(device=hidden_state.device, dtype=hidden_state.dtype)
                 
                 if target_init is None:
                 
                     target_init = hidden_state[0, lookup_idxs[0]].detach().clone()
 
                 for idxs_pre, delta_pre in all_delta:
+                    delta_pre_for_hidden = delta_pre.to(device=hidden_state.device, dtype=hidden_state.dtype)
                     for i, idx in enumerate(idxs_pre):
                         if len(idxs_pre)!=len(hidden_state):
-                            hidden_state[idx, i, :] += delta_pre
+                            hidden_state[idx, i, :] += delta_pre_for_hidden
                         else:
-                            hidden_state[i, idx, :] += delta_pre
+                            hidden_state[i, idx, :] += delta_pre_for_hidden
                 for i, idx in enumerate(lookup_idxs):
                     
                     if len(lookup_idxs)!=len(hidden_state):
-                        hidden_state[idx, i, :] += delta
+                        hidden_state[idx, i, :] += delta_for_hidden
                     else:
-                        hidden_state[i, idx, :] += delta
+                        hidden_state[i, idx, :] += delta_for_hidden
 
                 return nethook.replace_hidden_state(cur_out, hidden_state)
 
@@ -158,7 +162,8 @@ def compute_z(
                 output=torch.transpose(output, 0, 1)
             full_repr =  output
 
-            log_probs = torch.log_softmax(ln_f(full_repr) @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
+            full_repr = ln_f(full_repr)
+            log_probs = torch.log_softmax(full_repr @ lm_w.to(full_repr.device) + lm_b.to(full_repr.device), dim=2)
             loss = torch.gather(
                 log_probs,
                 2,
@@ -196,7 +201,7 @@ def compute_z(
                 with torch.no_grad():
                     delta[...] = delta * max_norm / delta.norm()
         cur_sen = ""
-        target = target_init + delta  
+        target = target_init + delta.to(device=target_init.device, dtype=target_init.dtype)
         all_delta.append((lookup_idxs ,delta.clone()))
         all_target.append(target)
         all_idxs.append(lookup_idxs[0])

--- a/easyeditor/models/unke_ARE/unke_ARE_main.py
+++ b/easyeditor/models/unke_ARE/unke_ARE_main.py
@@ -128,7 +128,10 @@ def apply_unke_ARE_to_model(
         targets_dict = {}
         for k, cur_zs_list in cur_zs_dict.items():
             zs_list = zs_dict[k]
-            targets_list = [(a - b)/(len(hparams.layers) - i) for a, b in zip(zs_list, cur_zs_list)]
+            targets_list = [
+                (a - b.to(device=a.device, dtype=a.dtype))/(len(hparams.layers) - i)
+                for a, b in zip(zs_list, cur_zs_list)
+            ]
             targets_dict[k] = targets_list
 
         ex_tok = tok(ex_data, padding=True, return_tensors="pt").to(
@@ -170,7 +173,7 @@ def apply_unke_ARE_to_model(
         for k, idxs_list in idxs_dict.items():
             for j, idx in enumerate(idxs_list):
                 resid = targets_dict[k][j]
-                layer_out_ks[k,idx]+=resid
+                layer_out_ks[k,idx]+=resid.to(device=layer_out_ks.device, dtype=layer_out_ks.dtype)
         
         # get_qwen2_causal_mask
         # llama2

--- a/easyeditor/util/device.py
+++ b/easyeditor/util/device.py
@@ -56,6 +56,24 @@ def get_model_device(model, fallback=None):
     return normalize_device(fallback)
 
 
+def get_module_device(module, fallback=None):
+    if module is not None and hasattr(module, "device"):
+        return normalize_device(module.device)
+
+    if module is not None:
+        try:
+            return next(module.parameters()).device
+        except (AttributeError, StopIteration):
+            pass
+
+        try:
+            return next(module.buffers()).device
+        except (AttributeError, StopIteration):
+            pass
+
+    return normalize_device(fallback)
+
+
 def copy_to_param(param, value):
     with torch.no_grad():
         if not torch.is_tensor(value):


### PR DESCRIPTION
﻿## Summary
- Add a helper to read the actual device of edited modules and create hook deltas on those module devices.
- Align hidden-state injections, final-layer logits, cached z/target tensors, and writeback/projection paths across ROME/R-ROME, MEMIT/EMMET/PMET, CORE/AlphaEdit/SPHERE, plus EAMET/UNKE/UNKE_ARE static counterparts.
- Fix the PMET dual attn/mlp weight-decay scalar path so sub-layer splits across GPUs do not add cross-device tensors.

## Root Cause
Some editors used `hparams.device` as the input, delta, solve, and writeback device. Under `device_map` or forced sharding, the edited layer can live on a different GPU, so hook-time tensor additions or later cached-vector math could hit cross-device errors.

## Validation
- Local `python -m py_compile` for all changed Python files.
- Local `git diff --check` for all changed files; only LF-to-CRLF working-copy warnings were emitted.
- A800 forced two-GPU matrix: 26/26 passed at `/data/xuhaoming/yfy/eval-results/forced-multicard/device-fix-all-final-20260609/matrix-summary.json`.
- A800 PMET sub-layer edge regression after review: 3/3 passed at `/data/xuhaoming/yfy/eval-results/forced-multicard/pmet-weight-decay-fix-20260609`.
- A800 PMET cross-GPU weight-decay autograd sanity confirmed gradients return to both original delta devices.
- A800 single-visible-GPU regression: FT/ROME/MEMIT/PMET/EMMET 10/10 passed, plus R-ROME/CORE/AlphaEdit/SPHERE extra smoke passed.
