### PR TITLE
Fix multimodal request preparation defaults

### DIFF
--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -194,11 +194,6 @@ class MultimodalEditor:
         else:
             prompts, targets, image = [prompts,], [targets,], [image,]
 
-        if file_type is None:
-            file_type = ["image" for _ in range(len(prompts))]
-        elif isinstance(file_type, str):
-            file_type = [file_type for _ in range(len(prompts))]
-
         if hasattr(self.hparams, 'batch_size'):  # For Singleton Editing, bs=1
             self.hparams.batch_size = 1
 

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -195,7 +195,9 @@ class MultimodalEditor:
             prompts, targets, image = [prompts,], [targets,], [image,]
 
         if file_type is None:
-            file_type = [None for _ in range(len(prompts))]
+            file_type = ["image" for _ in range(len(prompts))]
+        elif isinstance(file_type, str):
+            file_type = [file_type for _ in range(len(prompts))]
 
         if hasattr(self.hparams, 'batch_size'):  # For Singleton Editing, bs=1
             self.hparams.batch_size = 1
@@ -619,11 +621,18 @@ class MultimodalEditor:
                           file_type: Union[str, List[str]] = None,
                           **kwargs
                           ):
+        if isinstance(image, str):
+            image = [image, ]
+        if file_type is None:
+            file_type = ["image" for _ in range(len(prompts))]
+        elif isinstance(file_type, str):
+            file_type = [file_type for _ in range(len(prompts))]
+        if locality_inputs is None:
+            locality_inputs = {}
+
         if isinstance(file_type, List):
             assert len(file_type) == len(image) == len(prompts) == len(targets)
         
-        if isinstance(image, str):
-            image = [image, ]
         # image_path = [os.path.join(self.vis_root, image_) for image_ in image]
         # image = [Image.open(ip).convert("RGB") for ip in image_path]
         # image = [self.vis_tok(i).to(self.hparams.device) for i in image]


### PR DESCRIPTION
## Summary
- 将单图多模态编辑场景下缺省的 `file_type` 统一设为 `"image"`。
- 支持用户直接传入字符串形式的 `file_type`，并在内部归一化为逐请求列表。
- 在 `_prepare_requests()` 中将缺省的 `locality_inputs` 处理为空字典，避免未传 locality 时崩溃。

## Fixed Issues
- 修复普通单图编辑不显式传入 `file_type="image"` 时，`None` 被传入视觉处理器并触发报错的问题。
- 修复不传 `locality_inputs` 时，`_prepare_requests()` 直接调用 `locality_inputs.keys()` 导致的 `AttributeError`。

## Tests
- `git diff --check`
- `python -m py_compile easyeditor/editors/multimodal_editor.py`
- 使用最小复现脚本验证 `edit()` 会将缺省 `file_type` 归一化为 `["image"]`
- 使用最小复现脚本验证 `_prepare_requests()` 在 `locality_inputs=None` 且 `file_type=None` 时不再崩溃