### PR TITLE
Fix multimodal editor metrics, LoRA reset, and HF batch preparation

### DIFF
--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -572,7 +572,7 @@ class MultimodalEditor:
                     f"{i} editing: {request['prompt']} -> {request['target']}  \n {metrics}"
                 )
 
-                all_metrics.append(metrics)
+            all_metrics.append(metrics)
 
         return all_metrics, edited_model, weights_copy
 

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -572,7 +572,7 @@ class MultimodalEditor:
                     f"{i} editing: {request['prompt']} -> {request['target']}  \n {metrics}"
                 )
 
-            all_metrics.append(metrics)
+            all_metrics.append(metrics) #All metrics will be appended into all_metrics
 
         return all_metrics, edited_model, weights_copy
 

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -431,8 +431,6 @@ class MultimodalEditor:
                     del self.model.peft_config
                 elif self.alg_name == 'MELO':
                     self.model = edited_model
-                elif self.alg_name == 'LoRA' or self.alg_name == 'QLoRA' or self.alg_name == 'DPO':
-                    self.model = edited_model
                 else:
                     with torch.no_grad():
                         for k, v in weights_copy.items():
@@ -466,7 +464,8 @@ class MultimodalEditor:
                 request['prompt'] = kwargs['template'].format(request['prompt'])
 
             if self.alg_name == 'IKE':
-                assert 'train_ds' in kwargs.keys() or print('IKE need train_ds (For getting In-Context prompt)')
+                if 'train_ds' not in kwargs:
+                    raise ValueError("IKE editing requires train_ds for in-context prompt construction.")
                 edited_model, weights_copy, icl_examples = self.model, {}, self.apply_algo(
                     self.model,
                     self.tok,
@@ -572,7 +571,7 @@ class MultimodalEditor:
                     f"{i} editing: {request['prompt']} -> {request['target']}  \n {metrics}"
                 )
 
-            all_metrics.append(metrics) #All metrics will be appended into all_metrics
+            all_metrics.append(metrics)
 
         return all_metrics, edited_model, weights_copy
 

--- a/easyeditor/evaluate/multimodal_evaluate.py
+++ b/easyeditor/evaluate/multimodal_evaluate.py
@@ -215,8 +215,13 @@ def prepare_multimodal_hf_edit(hparams,
                             file_type):
     if isinstance(target, str):
         targets = [target, ]
+    else:
+        targets = target
     if isinstance(prompts, str):
         prompts = [prompts, ]
+
+    if len(prompts) != len(targets):
+        raise ValueError("prompts and target must have the same batch size.")
 
     if file_type == "text":       
         text_input = [processor.apply_chat_template([
@@ -246,32 +251,43 @@ def prepare_multimodal_hf_edit(hparams,
                                             tokenize=False) + l
                         for p, l in zip(prompts, targets)]
     elif file_type in ["image", "single-image", "multi-image"]:
-        if isinstance(image, List):
-            num_images = len(image)
+        if image is None:
+            images_list = [None for _ in range(len(prompts))]
+        elif file_type == "multi-image" and isinstance(image, List):
+            if len(prompts) == 1 and not any(isinstance(item, List) for item in image):
+                images_list = [image]
+            else:
+                images_list = image
+        elif isinstance(image, List):
+            images_list = image
         else:
-            num_images = 1
-            
-        text_input = [processor.apply_chat_template([
-                                {
+            images_list = [image for _ in range(len(prompts))]
 
-                                    "role": "user",
-                                    "content": [
-                                        {"type": "image"}
-                                    ] * num_images + [{"type": "text", "text": p}],
-                                },
-                            ],
-                                            add_generation_prompt=True,
-                                            tokenize=False) + l
-                        for p, l in zip(prompts, targets)]
-        if "qwen2-vl" in hparams.model_name.lower() and "|vision_start|" not in text_input[0]:
-            image_token = "<|vision_start|><|image_pad|><|vision_end|>"       
-            text_input = [image_token + text_input[0]]
+        if len(images_list) != len(prompts):
+            raise ValueError("image and prompts must have the same batch size.")
+
+        text_input = []
+        for p, l, img in zip(prompts, targets, images_list):
+            num_images = len(img) if isinstance(img, List) else 1
+
+            chat = processor.apply_chat_template([
+                {
+                    "role": "user",
+                    "content": [{"type": "image"}] * num_images + [{"type": "text", "text": p}],
+                },
+            ], add_generation_prompt=True, tokenize=False)
+
+            if "qwen2-vl" in hparams.model_name.lower() and "|vision_start|" not in chat:
+                image_token = "<|vision_start|><|image_pad|><|vision_end|>"
+                chat = image_token * num_images + chat
+
+            text_input.append(chat + l)
     else:
         raise AssertionError("Not support file type: {}".format(file_type))
     
     device = normalize_device(getattr(hparams, "device", None))
     if file_type in ["image", "single-image", "multi-image"]:
-        multimodal_inputs = processor(images=image, text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
+        multimodal_inputs = processor(images=images_list, text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
     elif file_type == "video":
         multimodal_inputs = processor(videos=image, text=text_input, return_tensors="pt").to(device, dtype=hparams.dtype)
     elif file_type == "text":


### PR DESCRIPTION
## Summary
- 修复 `edit_dataset()` 在 `verbose=False` 时不会保存 metrics 的问题。
- 清理 `MultimodalEditor.edit()` 中重复且不可达的 LoRA/QLoRA/DPO reset 分支。
- 修复 Qwen2-VL/HF 多模态 batch 构造中只使用第一条文本的问题。

## Fixed Issues
- `edit_dataset()` 原来只有在 `verbose=True` 时才会执行 `all_metrics.append(metrics)`，导致关闭 verbose 后返回的 metrics 列表为空。
- `MultimodalEditor.edit()` 中存在两段相同条件的 LoRA/QLoRA/DPO reset 逻辑，后一段分支永远不会执行，容易造成模型状态恢复逻辑不清晰。
- `prepare_multimodal_hf_edit()` 的 Qwen2-VL 分支原来使用 `text_input[0]` 处理整批文本，batch size > 1 时会导致后续样本的 prompt/target 被错误覆盖或丢失。

## Implementation Details
- 将 `all_metrics.append(metrics)` 移出 `if verbose:` 分支，保证每条 dataset edit 的结果都会被保存。
- 删除 `MultimodalEditor.edit()` 中重复的 LoRA/QLoRA/DPO reset 分支，保留实际可达的恢复逻辑。
- 在 `prepare_multimodal_hf_edit()` 中按样本构造 Qwen2-VL 的 image prompt 和 text prompt，确保 batch 内每条样本使用自己的 prompt、target 和 image 输入。
- 对 `prompts`、`target` 和 image batch 做长度检查，避免 batch 内样本数量不一致时静默错位。

## Tests
- `git diff --check`
- `python -m py_compile easyeditor/editors/multimodal_editor.py`
- `python -m py_compile easyeditor/evaluate/multimodal_evaluate.py`
- 使用最小脚本验证 `edit_dataset(verbose=False)` 时 metrics 会正常写入 `all_metrics`。
- 使用 Qwen2-VL processor 验证 `prepare_multimodal_hf_edit()` 在 batch size = 2 时，两条不同 prompt/target 不会串样本。
- 使用 `/mnt/20t/xuxin/qwen2vl_tmp_test/test1.jpg` 和 `test2.jpg` 进行真实 Qwen2-VL forward 测试，验证 single-image batch 和 multi-image single request 均可正常前向传播。