### PR TITLE
Fix sequential edit evaluation alignment and clarify locality metric protocols

### DIFF
--- a/easyeditor/editors/concept_editor.py
+++ b/easyeditor/editors/concept_editor.py
@@ -11,7 +11,11 @@ import logging
 import numpy as np
 import random
 from ..util.globals import *
-from ..evaluate import compute_concept_edit_quality
+from ..evaluate import (
+    attach_metric_meta,
+    build_locality_metric_meta,
+    compute_concept_edit_quality,
+)
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
@@ -233,6 +237,11 @@ class ConceptEditor:
                     for ans,label in zip(all_metrics[i]['post']['locality'][f'{locality_key}_output'],all_metrics[i]['pre']['locality'][f'{locality_key}_output']):
                         locality_result.append(np.mean(np.equal(ans, label)))
                     all_metrics[i]['post']['locality'][f'{locality_key}_acc'] = locality_result
+                    attach_metric_meta(
+                        all_metrics[i]['post'],
+                        f"locality.{locality_key}",
+                        build_locality_metric_meta(locality_key, self.hparams, self.model_name),
+                    )
                     all_metrics[i]['post']['locality'].pop(f'{locality_key}_output')
                 all_metrics[i]['pre'].pop('locality')
 

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -13,7 +13,13 @@ from transformers import GPT2TokenizerFast, GPT2Tokenizer
 from ..util.globals import *
 from .utils import _chunks, _prepare_requests, summary_metrics
 from .batch_editor import BatchEditor
-from ..evaluate import compute_edit_quality, compute_icl_edit_quality, compute_sent_metric
+from ..evaluate import (
+    attach_metric_meta,
+    build_locality_metric_meta,
+    compute_edit_quality,
+    compute_icl_edit_quality,
+    compute_sent_metric,
+)
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
@@ -275,6 +281,11 @@ class BaseEditor:
                             for ans, label in zip(chunk_metrics[i]['post']['locality'][f'{locality_key}_output'], chunk_metrics[i]['pre']['locality'][f'{locality_key}_output']):
                                 locality_result.append(np.mean(np.equal(ans, label)))
                         chunk_metrics[i]['post']['locality'][f'{locality_key}_acc'] = locality_result
+                        attach_metric_meta(
+                            chunk_metrics[i]['post'],
+                            f"locality.{locality_key}",
+                            build_locality_metric_meta(locality_key, self.hparams, self.model_name),
+                        )
                         chunk_metrics[i]['post']['locality'].pop(f'{locality_key}_output')
                     chunk_metrics[i]['pre'].pop('locality')
 
@@ -374,6 +385,11 @@ class BaseEditor:
                             for ans, label in zip(all_metrics[idx]['post']['locality'][f'{locality_key}_output'], all_metrics[idx]['pre']['locality'][f'{locality_key}_output']):
                                 locality_result.append(np.mean(np.equal(ans, label)))
                         all_metrics[idx]['post']['locality'][f'{locality_key}_acc'] = locality_result
+                        attach_metric_meta(
+                            all_metrics[idx]['post'],
+                            f"locality.{locality_key}",
+                            build_locality_metric_meta(locality_key, self.hparams, self.model_name),
+                        )
                         all_metrics[idx]['post']['locality'].pop(f'{locality_key}_output')
                     all_metrics[idx]['pre'].pop('locality')
 

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -384,13 +384,12 @@ class BaseEditor:
         if sequential_edit:
             for i, request in enumerate(tqdm(requests, total=len(requests))):
                 edited_model, weights_copy, icl_examples = edit_func(request)
+                edit_evaluation(all_metrics, request, edited_model, i, test_generation, icl_examples, **kwargs)
             if self.alg_name == 'LoRA' or self.alg_name == 'QLoRA' or self.alg_name == 'DPO':
                 self.model = edited_model
             if self.alg_name == 'WISE' and hasattr(self.hparams, 'save_path') and self.hparams.save_path:
                 print("Start saving the WISE model!")
                 edited_model.save(self.hparams.save_path)
-            for i, request in enumerate(requests):
-                edit_evaluation(all_metrics, request, edited_model, i, test_generation, icl_examples, **kwargs)
         else:
             for i, request in enumerate(tqdm(requests, total=len(requests))):
                 edited_model, weights_copy, icl_examples = edit_func(request)
@@ -602,7 +601,6 @@ class BaseEditor:
         if sequential_edit:
             for i, request in enumerate(tqdm(requests, total=len(requests))):
                 edited_model, weights_copy, icl_examples = edit_func(request)
-            for i, request in enumerate(requests):
                 post_edit_results(all_results, request, edited_model, i, eval_metric, test_generation, icl_examples, **kwargs)
         else:
             for i, request in enumerate(tqdm(requests, total=len(requests))):
@@ -636,4 +634,3 @@ class BaseEditor:
     ):
         metrics = self.apply_algo(datasets, self.hparams)
         return metrics
-

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -24,9 +24,13 @@ from transformers import AutoProcessor, LlavaOnevisionForConditionalGeneration, 
 
 from ..util.globals import *
 from .batch_editor import BatchEditor
-from ..evaluate import (compute_icl_multimodal_edit_quality, 
-                        compute_multimodal_edit_results,
-                        compute_multimodal_hf_edit_results)
+from ..evaluate import (
+    attach_metric_meta,
+    build_multimodal_locality_metric_meta,
+    compute_icl_multimodal_edit_quality,
+    compute_multimodal_edit_results,
+    compute_multimodal_hf_edit_results,
+)
 from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
@@ -293,6 +297,16 @@ class MultimodalEditor:
                     base_logits = torch.tensor(metrics['pre']['locality_output']).to(torch.float32)
                     post_logits = torch.tensor(metrics['post']['locality_output']).to(torch.float32)
                     metrics['post']['locality_acc'] = sum(post_logits.view(-1) == base_logits.view(-1))/base_logits.view(-1).shape[0]
+                    attach_metric_meta(
+                        metrics['post'],
+                        "locality.text",
+                        build_multimodal_locality_metric_meta(
+                            result_key="locality_acc",
+                            protocol="pre_post_full_logits_exact_match",
+                            scorer="logits_exact_match",
+                            comparable_group="locality.multimodal.full_logits_exact_match",
+                        ),
+                    )
                     metrics['post'].pop('locality_output')
                     metrics['pre'].pop('locality_output')
                     
@@ -302,6 +316,16 @@ class MultimodalEditor:
                     base_image_logits = torch.tensor(metrics['pre']['multimodal_locality_output']).to(torch.float32)
                     post_image_logits = torch.tensor(metrics['post']['multimodal_locality_output']).to(torch.float32)
                     metrics['post']['multimodal_locality_acc'] = sum(post_image_logits.view(-1) == base_image_logits.view(-1))/post_image_logits.view(-1).shape[0]
+                    attach_metric_meta(
+                        metrics['post'],
+                        "locality.image",
+                        build_multimodal_locality_metric_meta(
+                            result_key="multimodal_locality_acc",
+                            protocol="pre_post_full_logits_exact_match",
+                            scorer="logits_exact_match",
+                            comparable_group="locality.multimodal.full_logits_exact_match",
+                        ),
+                    )
                     metrics['post'].pop('multimodal_locality_output')
                     metrics['pre'].pop('multimodal_locality_output')
 
@@ -401,6 +425,16 @@ class MultimodalEditor:
                     base_logits = torch.tensor(metrics['pre']['locality_output']).to(torch.float32)
                     post_logits = torch.tensor(metrics['post']['locality_output']).to(torch.float32)
                     metrics['post']['locality_acc'] = sum(post_logits.view(-1) == base_logits.view(-1))/base_logits.view(-1).shape[0]
+                    attach_metric_meta(
+                        metrics['post'],
+                        "locality.text",
+                        build_multimodal_locality_metric_meta(
+                            result_key="locality_acc",
+                            protocol="pre_post_full_logits_exact_match",
+                            scorer="logits_exact_match",
+                            comparable_group="locality.multimodal.full_logits_exact_match",
+                        ),
+                    )
                     metrics['post'].pop('locality_output')
                     metrics['pre'].pop('locality_output')
                     
@@ -410,6 +444,16 @@ class MultimodalEditor:
                     base_image_logits = torch.tensor(metrics['pre']['multimodal_locality_output']).to(torch.float32)
                     post_image_logits = torch.tensor(metrics['post']['multimodal_locality_output']).to(torch.float32)
                     metrics['post']['multimodal_locality_acc'] = sum(post_image_logits.view(-1) == base_image_logits.view(-1))/post_image_logits.view(-1).shape[0]
+                    attach_metric_meta(
+                        metrics['post'],
+                        "locality.image",
+                        build_multimodal_locality_metric_meta(
+                            result_key="multimodal_locality_acc",
+                            protocol="pre_post_full_logits_exact_match",
+                            scorer="logits_exact_match",
+                            comparable_group="locality.multimodal.full_logits_exact_match",
+                        ),
+                    )
                     metrics['post'].pop('multimodal_locality_output')
                     metrics['pre'].pop('multimodal_locality_output')
 
@@ -545,6 +589,16 @@ class MultimodalEditor:
                 base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(base_logits, dim=-1), k=1, dim=-1).indices
                 post_base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(post_logits, dim=-1), k=1, dim=-1).indices
                 metrics['post']['locality_acc'] = sum(post_base_logits_softmax_top_k.view(-1) == base_logits_softmax_top_k.view(-1))/post_base_logits_softmax_top_k.view(-1).shape[0]
+                attach_metric_meta(
+                    metrics['post'],
+                    "locality.text",
+                    build_multimodal_locality_metric_meta(
+                        result_key="locality_acc",
+                        protocol="pre_post_top1_token_match",
+                        scorer="top1_token_match",
+                        comparable_group="locality.multimodal.pre_post_top1_token_match",
+                    ),
+                )
                 metrics['post'].pop('locality_output')
                 metrics['pre'].pop('locality_output')
                 
@@ -561,6 +615,16 @@ class MultimodalEditor:
                 base_image_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(base_image_logits, dim=-1), k=10, dim=-1).indices
                 post_image_base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(post_image_logits, dim=-1), k=10, dim=-1).indices
                 metrics['post']['multimodal_locality_acc'] = sum(post_image_base_logits_softmax_top_k.view(-1) == base_image_logits_softmax_top_k.view(-1))/post_image_base_logits_softmax_top_k.view(-1).shape[0]
+                attach_metric_meta(
+                    metrics['post'],
+                    "locality.image",
+                    build_multimodal_locality_metric_meta(
+                        result_key="multimodal_locality_acc",
+                        protocol="pre_post_top10_token_match",
+                        scorer="top10_token_match",
+                        comparable_group="locality.multimodal.pre_post_top10_token_match",
+                    ),
+                )
                 metrics['post'].pop('multimodal_locality_output')
                 metrics['pre'].pop('multimodal_locality_output')
 

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -227,6 +227,7 @@ class MultimodalEditor:
                                                                 request, self.hparams.device)
                 pre_edit_cache.append(pre_result)
 
+            all_metrics = []
             start = time()
             for i, request in enumerate(tqdm(requests, total=len(requests))):
                 if self.alg_name == 'IKE' and self.hparams.k == 0:
@@ -243,13 +244,7 @@ class MultimodalEditor:
                         keep_original_weight=keep_original_weight,
                         train_ds=None
                 )
-            exec_time = time() - start
-            if self.alg_name == 'WISE' and hasattr(self.hparams, 'save_path') and self.hparams.save_path:
-                print("Start saving the WISE model!")
-                edited_model.save(self.hparams.save_path)
-
-            all_metrics = []
-            for i, request in enumerate(tqdm(requests, total=len(requests), desc='Evaluating post-edit metrics')):
+                exec_time = time() - start
                 if self.alg_name == 'IKE':
                     if self.hparams.k != 0:
                         metrics = {
@@ -312,6 +307,10 @@ class MultimodalEditor:
 
                 LOG.info(f"Evaluation took {time() - start}")
                 all_metrics.append(metrics)
+
+            if self.alg_name == 'WISE' and hasattr(self.hparams, 'save_path') and self.hparams.save_path:
+                print("Start saving the WISE model!")
+                edited_model.save(self.hparams.save_path)
         
         # single editing
         else:

--- a/easyeditor/evaluate/evaluate.py
+++ b/easyeditor/evaluate/evaluate.py
@@ -36,6 +36,7 @@ from .metric_meta import (
     attach_metric_meta,
     build_icl_metric_meta,
     build_lm_metric_meta,
+    build_locality_metric_meta,
     merge_result_with_metric_meta,
 )
 
@@ -308,6 +309,11 @@ def compute_icl_edit_quality(
                 assert len(pre_neighbor) == len(post_neighbor)
 
                 ret['locality'][f'{locality_key}_acc'] = np.mean(np.equal(pre_neighbor, post_neighbor))
+            attach_metric_meta(
+                ret,
+                f"locality.{locality_key}",
+                build_locality_metric_meta(locality_key, hparams, model_name, icl=True),
+            )
     # Form a list of lists of prefixes to test.
     if 'portability' in record.keys() and any(record['portability']):
         for portability_key in record['portability'].keys():

--- a/easyeditor/evaluate/metric_meta.py
+++ b/easyeditor/evaluate/metric_meta.py
@@ -116,6 +116,36 @@ def build_icl_metric_meta(section, hparams, model_name):
     )
 
 
+def build_locality_metric_meta(locality_key, hparams, model_name, icl=False):
+    evaluation_type = getattr(hparams, "evaluation_type", None)
+    alg_name = getattr(hparams, "alg_name", getattr(hparams, "alg", None))
+    model_family = infer_model_family(model_name)
+
+    if icl:
+        protocol = "icl_pre_post_argmax_token_match"
+        scorer = "token_match"
+        comparable_group = "locality.lm.icl_pre_post_argmax_token_match"
+    elif evaluation_type in ["LLM-judge", "generate-text"]:
+        protocol = "pre_post_free_generation_output_match"
+        scorer = "exact_match"
+        comparable_group = "locality.lm.pre_post_free_generation_output_match"
+    elif alg_name == "GRACE" and model_family != "seq2seq":
+        protocol = "pre_post_generated_token_match"
+        scorer = "token_match"
+        comparable_group = "locality.lm.pre_post_generated_token_match"
+    else:
+        protocol = "pre_post_argmax_token_match"
+        scorer = "token_match"
+        comparable_group = "locality.lm.pre_post_argmax_token_match"
+
+    return _base_meta(
+        result_key=f"locality.{locality_key}_acc",
+        protocol=protocol,
+        scorer=scorer,
+        comparable_group=comparable_group,
+    )
+
+
 def build_multimodal_metric_meta(
     section,
     hparams,
@@ -131,6 +161,21 @@ def build_multimodal_metric_meta(
         protocol = f"{protocol}_exact_match"
         scorer = "sequence_exact_match"
         comparable_group = f"{comparable_group.rsplit('.', 1)[0]}.sequence_exact_match"
+    return _base_meta(
+        result_key=result_key,
+        protocol=protocol,
+        scorer=scorer,
+        comparable_group=comparable_group,
+    )
+
+
+def build_multimodal_locality_metric_meta(
+    *,
+    result_key,
+    protocol,
+    scorer,
+    comparable_group,
+):
     return _base_meta(
         result_key=result_key,
         protocol=protocol,

--- a/easyeditor/models/r_rome/layer_stats.py
+++ b/easyeditor/models/r_rome/layer_stats.py
@@ -37,7 +37,7 @@ def main():
         parser.add_argument(*args, **kwargs)
 
     aa("--model_name", default="gpt2-xl", choices=["gpt2-xl", "EleutherAI/gpt-j-6B"])
-    aa("--dataset", default="wikipedia", choices=["wikitext", "wikipedia"])
+    aa("--dataset", default="wikipedia", choices=["wikitext", "wikitext2", "wikipedia"])
     aa("--layers", default=[17], type=lambda x: list(map(int, x.split(","))))
     aa("--to_collect", default=["mom2"], type=lambda x: x.split(","))
     aa("--sample_size", default=100000, type=lambda x: None if x == "all" else int(x))
@@ -101,10 +101,13 @@ def layer_stats(
         # from datasets import Dataset
         # raw_ds = Dataset.from_file('XXX/XXX/wikipedia-train.arrow')
         # raw_ds = {'train': raw_ds}
-        raw_ds = load_dataset(
-            ds_name,
-            dict(wikitext="wikitext-103-raw-v1", wikipedia="20200501.en")[ds_name]
-        )
+        dataset_map = {
+            "wikitext": ("Salesforce/wikitext", "wikitext-103-raw-v1"),
+            "wikitext2": ("Salesforce/wikitext", "wikitext-2-raw-v1"),
+            "wikipedia": ("wikimedia/wikipedia", "20231101.en"),
+        }
+        dataset_name, dataset_config = dataset_map[ds_name]
+        raw_ds = load_dataset(dataset_name, dataset_config)
         if hasattr(model.config, 'n_positions'):
             maxlen = model.config.n_positions
         elif hasattr(model.config, 'max_sequence_length'):

--- a/easyeditor/models/rome/layer_stats.py
+++ b/easyeditor/models/rome/layer_stats.py
@@ -37,7 +37,7 @@ def main():
         parser.add_argument(*args, **kwargs)
 
     aa("--model_name", default="gpt2-xl", choices=["gpt2-xl", "EleutherAI/gpt-j-6B"])
-    aa("--dataset", default="wikipedia", choices=["wikitext", "wikipedia"])
+    aa("--dataset", default="wikipedia", choices=["wikitext", "wikitext2", "wikipedia"])
     aa("--layers", default=[17], type=lambda x: list(map(int, x.split(","))))
     aa("--to_collect", default=["mom2"], type=lambda x: x.split(","))
     aa("--sample_size", default=100000, type=lambda x: None if x == "all" else int(x))
@@ -101,10 +101,13 @@ def layer_stats(
         # from datasets import Dataset
         # raw_ds = Dataset.from_file('XXX/XXX/wikipedia-train.arrow')
         # raw_ds = {'train': raw_ds}
-        raw_ds = load_dataset(
-            ds_name,
-            dict(wikitext="wikitext-103-raw-v1", wikipedia="20200501.en")[ds_name]
-        )
+        dataset_map = {
+            "wikitext": ("Salesforce/wikitext", "wikitext-103-raw-v1"),
+            "wikitext2": ("Salesforce/wikitext", "wikitext-2-raw-v1"),
+            "wikipedia": ("wikimedia/wikipedia", "20231101.en"),
+        }
+        dataset_name, dataset_config = dataset_map[ds_name]
+        raw_ds = load_dataset(dataset_name, dataset_config)
         if hasattr(model.config, 'n_positions'):
             maxlen = model.config.n_positions
         elif hasattr(model.config, 'max_sequence_length'):


### PR DESCRIPTION
## Summary

This PR addresses two evaluation issues.

### 1. Fix sequential editing post-evaluation alignment

Previously, sequential editing could evaluate all requests using the final edited model state. This made `post` metrics misaligned: request 0, request 1, etc. were not necessarily evaluated against the model state immediately after their own edit.

This PR updates sequential evaluation so each request is evaluated right after its corresponding edit is applied.

### 2. Clarify locality metric protocols with `metric_meta`

`locality_acc` is not computed with one universal protocol across EasyEdit. Depending on the entry point, it can mean pre/post argmax token match, generation token match, full logits exact match, or top-k token match.

This PR adds lightweight `metric_meta` entries for locality metrics so downstream users can see how each metric was computed without changing existing metric values.

Each `metric_meta` entry contains:

```json
{
  "result_key": "the concrete metric field this metadata describes",
  "protocol": "the evaluation protocol used to produce the metric",
  "scorer": "the scoring rule used by that protocol",
  "comparable_group": "the group of metrics that are directly comparable"
}