### PR TITLE
Fix summary metric discovery and missing ground_truth handling

### DIFF
--- a/easyeditor/editors/concept_editor.py
+++ b/easyeditor/editors/concept_editor.py
@@ -20,6 +20,7 @@ from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
 from ..util.device import copy_to_param, normalize_device
+from .utils import normalize_ground_truths
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt = '%m/%d/%Y %H:%M:%S',
@@ -160,13 +161,7 @@ class ConceptEditor:
         if hasattr(self.hparams, 'batch_size'):  # For Singleton Editing, bs=1
             self.hparams.batch_size = 1
 
-        if ground_truth is not None:
-            if isinstance(ground_truth, str):
-                ground_truth = [ground_truth,]
-            else:
-                assert len(ground_truth) == len(prompts)
-        else: # Default ground truth is <|endoftext|>
-            ground_truth = ['<|endoftext|>' for _ in range(len(prompts))]
+        ground_truth = normalize_ground_truths(ground_truth, prompts)
             
         if "requests" in kwargs.keys():
             requests = kwargs["requests"]

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -11,7 +11,7 @@ from transformers import LlamaTokenizer,PreTrainedTokenizerFast, LlamaTokenizerF
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 from transformers import GPT2TokenizerFast, GPT2Tokenizer
 from ..util.globals import *
-from .utils import _chunks, _prepare_requests, restore_after_edit, summary_metrics
+from .utils import _chunks, _prepare_requests, normalize_ground_truths, restore_after_edit, summary_metrics
 from .batch_editor import BatchEditor
 from ..evaluate import (
     attach_metric_meta,
@@ -180,10 +180,7 @@ class BaseEditor:
         if hasattr(self.hparams, 'batch_size') and not BatchEditor.is_batchable_method(self.alg_name):  # For Singleton Editing, bs=1
             assert self.hparams.batch_size == 1, 'Single Editing: batch_size should be set to 1'
 
-        if ground_truth is not None:
-            ground_truth = [ground_truth,] if isinstance(ground_truth, str) else ground_truth
-        else:# Default ground truth is <|endoftext|>
-            ground_truth = ['<|endoftext|>'] * (len(prompts))
+        ground_truth = normalize_ground_truths(ground_truth, prompts)
 
         if "requests" in kwargs.keys():
             requests = kwargs["requests"]
@@ -212,13 +209,7 @@ class BaseEditor:
         """
         assert len(prompts) == len(target_new)
         test_generation = kwargs['test_generation'] if 'test_generation' in kwargs.keys() else False
-        if ground_truth is not None:
-            if isinstance(ground_truth, str):
-                ground_truth = [ground_truth,]
-            else:
-                assert len(ground_truth) == len(prompts)
-        else: # Default ground truth is <|endoftext|>
-            ground_truth = ['<|endoftext|>' for _ in range(len(prompts))]
+        ground_truth = normalize_ground_truths(ground_truth, prompts)
 
 
         assert BatchEditor.is_batchable_method(self.alg_name), f'The Method {self.alg_name} can not batch edit examples.'
@@ -422,7 +413,7 @@ class BaseEditor:
             the ground truth / expected output
         """
         assert len(prompts) == len(target_new)
-        ground_truth = ['<|endoftext|>' for _ in range(len(prompts))]
+        ground_truth = normalize_ground_truths(None, prompts)
 
 
         assert BatchEditor.is_batchable_method(self.alg_name), f'The Method {self.alg_name} can not batch edit examples.'
@@ -471,10 +462,15 @@ class BaseEditor:
         eval_metric= kwargs['eval_metric'] if 'eval_metric' in kwargs.keys() else 'exact match'
         test_generation = kwargs.pop('test_generation', False)
 
-        assert len(prompts) == len(target_new)
+        if isinstance(prompts, List):
+            assert len(prompts) == len(target_new)
+        else:
+            prompts, target_new = [prompts,], [target_new,]
 
         if hasattr(self.hparams, 'batch_size'):
             assert self.hparams.batch_size == 1, 'Single Editing: batch_size should be set to 1'
+
+        ground_truth = normalize_ground_truths(ground_truth, prompts)
         
         if "requests" in kwargs.keys():
             requests = kwargs["requests"]

--- a/easyeditor/editors/safety_editor.py
+++ b/easyeditor/editors/safety_editor.py
@@ -15,6 +15,7 @@ from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
 from ..util.device import copy_to_param, move_to_device, normalize_device
+from .utils import normalize_ground_truths
 
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
@@ -101,6 +102,12 @@ class SafetyEditor:
         # else:
         #     tokenizer.padding_side = 'left'
         toxic_layer = []
+        for request in requests:
+            if request.get("ground_truth") is None:
+                raise ValueError(
+                    "Safety layer localization requires `ground_truth`, "
+                    "but it was not provided. Please pass `ground_truth` explicitly."
+                )
         input = move_to_device(tokenizer([value for pair in requests for value in [pair["target_new"], pair["ground_truth"]]], return_tensors="pt", padding=True, truncation=True), self.hparams.device)
         with torch.no_grad():
             outputs = model(**input)
@@ -148,13 +155,7 @@ class SafetyEditor:
         if hasattr(self.hparams, 'batch_size'):  # For Singleton Editing, bs=1
             self.hparams.batch_size = 1
 
-        if ground_truth is not None:
-            if isinstance(ground_truth, str):
-                ground_truth = [ground_truth,]
-            else:
-                assert len(ground_truth) == len(prompts)
-        else: # Default ground truth is <|endoftext|>
-            ground_truth = ['<|endoftext|>' for _ in range(len(prompts))]
+        ground_truth = normalize_ground_truths(ground_truth, prompts)
 
         if "requests" in kwargs.keys():
             requests = kwargs["requests"]

--- a/easyeditor/editors/utils.py
+++ b/easyeditor/editors/utils.py
@@ -64,6 +64,25 @@ def get_all_acc_keys(dict_list):
 
     return all_keys
 
+def get_section_acc_keys(dict_list, phase, section):
+    all_keys = set()
+    for metric in dict_list:
+        phase_metrics = metric.get(phase, {})
+        section_metrics = phase_metrics.get(section, {})
+        if isinstance(section_metrics, dict):
+            for key in section_metrics.keys():
+                if key.endswith("acc"):
+                    all_keys.add(key)
+    return all_keys
+
+def collect_metric_values(dict_list, phase, key):
+    values = []
+    for metric in dict_list:
+        phase_metrics = metric.get(phase, {})
+        if key in phase_metrics:
+            values.append(phase_metrics[key])
+    return values
+
 def get_metric_protocol_summary(dict_list):
     protocol_summary = {}
     for metric in dict_list:
@@ -94,17 +113,21 @@ def summary_metrics(all_metrics):
     for eval in ["pre", "post"]:
         mean_metrics[eval] = dict()
         for key in ["rewrite_acc", "rephrase_acc", 'rewrite_ppl', 'ood_acc']:
-            if key in all_metrics[0][eval].keys():
-                mean_metrics[eval][key] = np.mean([metric[eval][key] for metric in all_metrics])
-        for key in ["locality", "portability"]:
-            if key in all_metrics[0][eval].keys() and all_metrics[0][eval][key] != {}:
-                mean_metrics[eval][key] = dict()
-                for lkey in get_all_acc_keys(all_metrics):
-                    metrics = [np.mean(metric[eval][key][lkey]) for metric in all_metrics if lkey in metric[eval][key].keys()]
+            values = collect_metric_values(all_metrics, eval, key)
+            if len(values) > 0:
+                mean_metrics[eval][key] = np.mean(values)
+        for section in ["locality", "portability"]:
+            section_keys = get_section_acc_keys(all_metrics, eval, section)
+            if len(section_keys) > 0:
+                mean_metrics[eval][section] = dict()
+                for lkey in section_keys:
+                    metrics = []
+                    for metric in all_metrics:
+                        section_metrics = metric.get(eval, {}).get(section, {})
+                        if isinstance(section_metrics, dict) and lkey in section_metrics:
+                            metrics.append(np.mean(section_metrics[lkey]))
                     if len(metrics) > 0:
-                        mean_metrics[eval][key][lkey] = np.mean(metrics)
-                    # mean_metrics[eval][key][lkey] = np.mean(
-                    #     [metric[eval][key][lkey] for metric in all_metrics])
+                        mean_metrics[eval][section][lkey] = np.mean(metrics)
     # mean_metrics["time"] = np.mean([metric["time"] for metric in all_metrics])
     protocol_summary = get_metric_protocol_summary(all_metrics)
     if protocol_summary:

--- a/easyeditor/editors/utils.py
+++ b/easyeditor/editors/utils.py
@@ -15,6 +15,20 @@ PEFT_RESTORE_ALGS = {"LoRA", "QLoRA", "DPO"}
 KEEP_EDITED_MODEL_ALGS = {"MELO"}
 
 
+def normalize_ground_truths(
+    ground_truth: Optional[Union[str, List[str]]],
+    prompts: List[str],
+) -> List[Optional[str]]:
+    if ground_truth is None:
+        return [None for _ in prompts]
+
+    if isinstance(ground_truth, str):
+        ground_truth = [ground_truth]
+
+    assert len(ground_truth) == len(prompts)
+    return ground_truth
+
+
 def restore_after_edit(editor, edited_model, weights_copy):
     """Restore editor.model after a non-sequential edit."""
     alg_name = getattr(editor, "alg_name", None)

--- a/easyeditor/models/core/compute_z.py
+++ b/easyeditor/models/core/compute_z.py
@@ -14,6 +14,16 @@ from ...util.generate import generate_fast
 from itertools import combinations
 
 
+def get_required_ground_truth_for_context(request: Dict, context_type: str):
+    ground_truth = request.get("ground_truth")
+    if ground_truth is None:
+        raise ValueError(
+            f"CORE context `{context_type}` uses `ground_truth`, "
+            "but no `ground_truth` was provided. Please pass it explicitly."
+        )
+    return ground_truth
+
+
 
 def compute_z(
     model: AutoModelForCausalLM,
@@ -280,14 +290,14 @@ def get_context_templates(model, tok, request, context_type='all', n_gen=5, max_
 
     # 2) Prompt setup and calculation of n_gen_per_prompt (ensure at least 1)
     if context_type == 'all':
-        ground_truth = request["ground_truth"]
+        ground_truth = get_required_ground_truth_for_context(request, context_type)
         subject      = request["subject"]
         target_new   = request["target_new"]
         all_prompts  = [ground_truth, subject, target_new]
         n_gen_per_prompt = max(n_gen // len(all_prompts), 1)
 
     elif context_type == 'target_true_n_subject':
-        ground_truth = request["ground_truth"]
+        ground_truth = get_required_ground_truth_for_context(request, context_type)
         subject      = request["subject"]
         all_prompts  = [ground_truth, subject]
         n_gen_per_prompt = max(n_gen // len(all_prompts), 1)
@@ -298,7 +308,10 @@ def get_context_templates(model, tok, request, context_type='all', n_gen=5, max_
             'target_new' : 'target_new',
             'subject'    : 'subject'
         }
-        target = request[prompt_key[context_type]]
+        if context_type == 'target_true':
+            target = get_required_ground_truth_for_context(request, context_type)
+        else:
+            target = request[prompt_key[context_type]]
         all_prompts = [target]
         n_gen_per_prompt = n_gen
 

--- a/easyeditor/models/kn/kn_main.py
+++ b/easyeditor/models/kn/kn_main.py
@@ -30,7 +30,12 @@ def apply_kn_to_model(
     )
     request_rewrite = deepcopy(request)
     text = [request_rewrite["prompt"]]
-    ground_truth = request_rewrite["ground_truth"]
+    ground_truth = request_rewrite.get("ground_truth")
+    if ground_truth is None:
+        raise ValueError(
+            "KN requires `ground_truth` as the original target, "
+            "but it was not provided. Please pass `ground_truth` explicitly."
+        )
     target = request_rewrite["target_new"]
 
     # kn.model = kn.model.to(kn.device)


### PR DESCRIPTION
## Summary

This PR fixes two evaluation/reporting issues.

First, `summary_metrics()` previously discovered metric fields only from the first sample. If the first sample did not contain fields such as `rephrase`, `locality`, or `portability`, but later samples did, those fields were skipped in the final summary.

Second, missing request-level `ground_truth` was previously filled with `"<|endoftext|>"`. This created a synthetic old target and could mislead algorithms or statistics that treat `ground_truth` as the original target.

## Changes

### 1. Fix summary metric field discovery

- Discover `*_acc` fields across all samples instead of only using the first sample.
- Aggregate available values from each sample safely.
- Preserve existing metric values and output structure.

### 2. Avoid synthetic `ground_truth`

- Keep missing `ground_truth` as `None`.
- Remove request-level `"<|endoftext|>"` default.
- Add clear missing-`ground_truth` errors for paths that require an original target:
  - KN
  - Safety layer localization
  - CORE contexts that use `ground_truth`

## Validation

Validated with static checks and targeted smoke tests.

For `summary_metrics()`:
- `compileall`
- `git diff --check`
- mock test where the first sample lacks `rephrase/locality/portability`, while later samples contain them; confirmed those fields are included in the summary.

For `ground_truth` handling:
- `compileall`
- `git diff --check`
- static scan confirming no request-level default `"<|endoftext|>"` remains
- request construction keeps missing `ground_truth` as `null`
- KN / CORE / Safety missing-`ground_truth` paths raise clear errors
- Qwen2.5-1.5B-Instruct FT smoke validation confirms `requested_rewrite["ground_truth"]` is `null`