### PR TITLE
Fix multimodal batch locality and WISE masks

### DIFF
--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -36,6 +36,7 @@ from ..util import nethook
 from ..util.hparams import HyperParams
 from ..util.alg_dict import *
 from ..util.device import copy_to_param, normalize_device
+from ..util.multimodal import topk_token_match
 
 logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt = '%m/%d/%Y %H:%M:%S',
@@ -49,6 +50,50 @@ def make_logs():
     f_h, s_h = get_handler("logs/", log_name='run.log')
     LOG.addHandler(f_h)
     LOG.addHandler(s_h)
+
+
+def attach_topk_locality_metrics(metrics):
+    if 'locality_output' in metrics['post'].keys():
+        assert len(metrics['post']['locality_output']) == \
+                len(metrics['pre']['locality_output'])
+        metrics['post']['locality_acc'] = topk_token_match(
+            metrics['pre']['locality_output'],
+            metrics['post']['locality_output'],
+            k=1,
+        )
+        attach_metric_meta(
+            metrics['post'],
+            "locality.text",
+            build_multimodal_locality_metric_meta(
+                result_key="locality_acc",
+                protocol="pre_post_top1_token_match",
+                scorer="top1_token_match",
+                comparable_group="locality.multimodal.pre_post_top1_token_match",
+            ),
+        )
+        metrics['post'].pop('locality_output')
+        metrics['pre'].pop('locality_output')
+
+    if 'multimodal_locality_output' in metrics['post'].keys():
+        assert len(metrics['post']['multimodal_locality_output']) == \
+                len(metrics['pre']['multimodal_locality_output'])
+        metrics['post']['multimodal_locality_acc'] = topk_token_match(
+            metrics['pre']['multimodal_locality_output'],
+            metrics['post']['multimodal_locality_output'],
+            k=10,
+        )
+        attach_metric_meta(
+            metrics['post'],
+            "locality.image",
+            build_multimodal_locality_metric_meta(
+                result_key="multimodal_locality_acc",
+                protocol="pre_post_top10_token_match",
+                scorer="top10_token_match",
+                comparable_group="locality.multimodal.pre_post_top10_token_match",
+            ),
+        )
+        metrics['post'].pop('multimodal_locality_output')
+        metrics['pre'].pop('multimodal_locality_output')
 
 
 class MultimodalEditor:
@@ -292,43 +337,7 @@ class MultimodalEditor:
                             "pre": pre_edit_cache[i]
                         }
                                 
-                if 'locality_output' in metrics['post'].keys():
-                    assert len(metrics['post']['locality_output']) == \
-                            len(metrics['pre']['locality_output'])
-                    base_logits = torch.tensor(metrics['pre']['locality_output']).to(torch.float32)
-                    post_logits = torch.tensor(metrics['post']['locality_output']).to(torch.float32)
-                    metrics['post']['locality_acc'] = sum(post_logits.view(-1) == base_logits.view(-1))/base_logits.view(-1).shape[0]
-                    attach_metric_meta(
-                        metrics['post'],
-                        "locality.text",
-                        build_multimodal_locality_metric_meta(
-                            result_key="locality_acc",
-                            protocol="pre_post_full_logits_exact_match",
-                            scorer="logits_exact_match",
-                            comparable_group="locality.multimodal.full_logits_exact_match",
-                        ),
-                    )
-                    metrics['post'].pop('locality_output')
-                    metrics['pre'].pop('locality_output')
-                    
-                if 'multimodal_locality_output' in metrics['post'].keys():
-                    assert len(metrics['post']['multimodal_locality_output']) == \
-                            len(metrics['pre']['multimodal_locality_output'])
-                    base_image_logits = torch.tensor(metrics['pre']['multimodal_locality_output']).to(torch.float32)
-                    post_image_logits = torch.tensor(metrics['post']['multimodal_locality_output']).to(torch.float32)
-                    metrics['post']['multimodal_locality_acc'] = sum(post_image_logits.view(-1) == base_image_logits.view(-1))/post_image_logits.view(-1).shape[0]
-                    attach_metric_meta(
-                        metrics['post'],
-                        "locality.image",
-                        build_multimodal_locality_metric_meta(
-                            result_key="multimodal_locality_acc",
-                            protocol="pre_post_full_logits_exact_match",
-                            scorer="logits_exact_match",
-                            comparable_group="locality.multimodal.full_logits_exact_match",
-                        ),
-                    )
-                    metrics['post'].pop('multimodal_locality_output')
-                    metrics['pre'].pop('multimodal_locality_output')
+                attach_topk_locality_metrics(metrics)
 
                 LOG.info(f"Evaluation took {time() - start}")
                 all_metrics.append(metrics)
@@ -420,43 +429,7 @@ class MultimodalEditor:
                         }   
                      
                     
-                if 'locality_output' in metrics['post'].keys():
-                    assert len(metrics['post']['locality_output']) == \
-                            len(metrics['pre']['locality_output'])
-                    base_logits = torch.tensor(metrics['pre']['locality_output']).to(torch.float32)
-                    post_logits = torch.tensor(metrics['post']['locality_output']).to(torch.float32)
-                    metrics['post']['locality_acc'] = sum(post_logits.view(-1) == base_logits.view(-1))/base_logits.view(-1).shape[0]
-                    attach_metric_meta(
-                        metrics['post'],
-                        "locality.text",
-                        build_multimodal_locality_metric_meta(
-                            result_key="locality_acc",
-                            protocol="pre_post_full_logits_exact_match",
-                            scorer="logits_exact_match",
-                            comparable_group="locality.multimodal.full_logits_exact_match",
-                        ),
-                    )
-                    metrics['post'].pop('locality_output')
-                    metrics['pre'].pop('locality_output')
-                    
-                if 'multimodal_locality_output' in metrics['post'].keys():
-                    assert len(metrics['post']['multimodal_locality_output']) == \
-                            len(metrics['pre']['multimodal_locality_output'])
-                    base_image_logits = torch.tensor(metrics['pre']['multimodal_locality_output']).to(torch.float32)
-                    post_image_logits = torch.tensor(metrics['post']['multimodal_locality_output']).to(torch.float32)
-                    metrics['post']['multimodal_locality_acc'] = sum(post_image_logits.view(-1) == base_image_logits.view(-1))/post_image_logits.view(-1).shape[0]
-                    attach_metric_meta(
-                        metrics['post'],
-                        "locality.image",
-                        build_multimodal_locality_metric_meta(
-                            result_key="multimodal_locality_acc",
-                            protocol="pre_post_full_logits_exact_match",
-                            scorer="logits_exact_match",
-                            comparable_group="locality.multimodal.full_logits_exact_match",
-                        ),
-                    )
-                    metrics['post'].pop('multimodal_locality_output')
-                    metrics['pre'].pop('multimodal_locality_output')
+                attach_topk_locality_metrics(metrics)
 
 
                 LOG.info(f"Evaluation took {time() - start}")
@@ -565,57 +538,7 @@ class MultimodalEditor:
                 #     "pre": compute_multimodal_edit_results(self.model, self.model_name, self.hparams, self.tok,
                 #                                         request, self.hparams.device)
                 # }
-            if 'locality_output' in metrics['post'].keys():
-                assert len(metrics['post']['locality_output']) == \
-                        len(metrics['pre']['locality_output'])
-                base_logits = metrics['pre']['locality_output'].to(torch.float32)
-                post_logits = metrics['post']['locality_output'].to(torch.float32)
-                if post_logits.shape[1] > base_logits.shape[1]:
-                    post_logits = post_logits[:, -base_logits.shape[1]:, :]
-                else:
-                    base_logits = base_logits[:, -post_logits.shape[1]:, :]
-
-                base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(base_logits, dim=-1), k=1, dim=-1).indices
-                post_base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(post_logits, dim=-1), k=1, dim=-1).indices
-                metrics['post']['locality_acc'] = sum(post_base_logits_softmax_top_k.view(-1) == base_logits_softmax_top_k.view(-1))/post_base_logits_softmax_top_k.view(-1).shape[0]
-                attach_metric_meta(
-                    metrics['post'],
-                    "locality.text",
-                    build_multimodal_locality_metric_meta(
-                        result_key="locality_acc",
-                        protocol="pre_post_top1_token_match",
-                        scorer="top1_token_match",
-                        comparable_group="locality.multimodal.pre_post_top1_token_match",
-                    ),
-                )
-                metrics['post'].pop('locality_output')
-                metrics['pre'].pop('locality_output')
-                
-            if 'multimodal_locality_output' in metrics['post'].keys():
-                assert len(metrics['post']['multimodal_locality_output']) == \
-                        len(metrics['pre']['multimodal_locality_output'])
-                base_image_logits = metrics['pre']['multimodal_locality_output'].to(torch.float32)
-                post_image_logits = metrics['post']['multimodal_locality_output'].to(torch.float32)
-                if post_image_logits.shape[1] > base_image_logits.shape[1]:
-                    post_image_logits = post_image_logits[:, -base_image_logits.shape[1]:, :]
-                else:
-                    base_image_logits = base_image_logits[:, -post_image_logits.shape[1]:, :]
-
-                base_image_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(base_image_logits, dim=-1), k=10, dim=-1).indices
-                post_image_base_logits_softmax_top_k = torch.topk(torch.nn.functional.softmax(post_image_logits, dim=-1), k=10, dim=-1).indices
-                metrics['post']['multimodal_locality_acc'] = sum(post_image_base_logits_softmax_top_k.view(-1) == base_image_logits_softmax_top_k.view(-1))/post_image_base_logits_softmax_top_k.view(-1).shape[0]
-                attach_metric_meta(
-                    metrics['post'],
-                    "locality.image",
-                    build_multimodal_locality_metric_meta(
-                        result_key="multimodal_locality_acc",
-                        protocol="pre_post_top10_token_match",
-                        scorer="top10_token_match",
-                        comparable_group="locality.multimodal.pre_post_top10_token_match",
-                    ),
-                )
-                metrics['post'].pop('multimodal_locality_output')
-                metrics['pre'].pop('multimodal_locality_output')
+            attach_topk_locality_metrics(metrics)
 
             LOG.info(f"Evaluation took {time() - start}")
 

--- a/easyeditor/models/grace/utils.py
+++ b/easyeditor/models/grace/utils.py
@@ -6,6 +6,7 @@ import datetime
 import struct
 from torch.nn.utils.rnn import pad_sequence
 import torch.nn.functional as F
+from ...util.multimodal import build_target_labels, count_media_items, get_batch_file_type
 
 def get_inner_params(named_parameters, inner_names):
     param_dict = dict(named_parameters)
@@ -89,7 +90,7 @@ def multimodal_tokenize(batch, processor, device, hparams):
     prompts = [item['prompt'] for item in batch]
     input_images = [item['image'] for item in batch]
     labels = [item['target'] for item in batch]
-    file_type = batch[0]['file_type']
+    file_type = get_batch_file_type(batch)
     mask_token = -100 # ignore_index of CrossEntropyLoss
     if file_type == "video":
         temp_prompt = [processor.apply_chat_template([
@@ -106,12 +107,10 @@ def multimodal_tokenize(batch, processor, device, hparams):
                                             tokenize=False) + l
                         for p, l in zip(prompts, labels)] 
     elif file_type in ["image", "single-image", "multi-image"]:
-        if file_type == "multi-image":
-            num_images = len(input_images[0])
-        else:
-            num_images = 1
-        
-        temp_prompt = [processor.apply_chat_template([
+        temp_prompt = []
+        for p, l, img in zip(prompts, labels, input_images):
+            num_images = count_media_items(img, file_type)
+            temp_prompt.append(processor.apply_chat_template([
                                 {
 
                                     "role": "user",
@@ -119,8 +118,7 @@ def multimodal_tokenize(batch, processor, device, hparams):
                                 },
                             ],
                                             add_generation_prompt=True,
-                                            tokenize=False)  + l
-                        for p, l in zip(prompts, labels)]
+                                            tokenize=False) + l)
     else:
         raise AssertionError("Not support file type: {}".format(file_type))
     
@@ -128,16 +126,11 @@ def multimodal_tokenize(batch, processor, device, hparams):
     if file_type in ["image", "single-image", "multi-image"]:
         multimodal_inputs = processor(images=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
     elif file_type == "video":
-        multimodal_inputs = processor(videos=input_images[0], text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
+        multimodal_inputs = processor(videos=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
         
     
     tokens = multimodal_inputs
     
-    targets = processor.tokenizer(labels[0], add_special_tokens=False,
-                    return_tensors="pt", padding=True, max_length=multimodal_inputs["input_ids"].size(1))["input_ids"]
-
-    labels_ids = torch.full_like(multimodal_inputs["input_ids"], -100)
-    labels_ids[:, -targets.size(1):] = targets
-    tokens["labels"] = labels_ids
+    tokens["labels"] = build_target_labels(multimodal_inputs["input_ids"], processor.tokenizer, labels)
     tokens = tokens.to(device)
     return tokens

--- a/easyeditor/models/lora/lora_main.py
+++ b/easyeditor/models/lora/lora_main.py
@@ -5,6 +5,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoProcessor
 
 from ...util.device import normalize_device
+from ...util.multimodal import build_target_labels, count_media_items, get_batch_file_type
 from .lora_hparams import LoRAHyperParams
 from .lora_multimodal_hparams import LoRAMultimodalHyperParams
 
@@ -260,7 +261,7 @@ def execute_multimodal_lora(
     # Define inputs
     prompts = [r["prompt"] for r in requests]
     labels = [r["target"] for r in requests]
-    file_type = requests[0]['file_type']
+    file_type = get_batch_file_type(requests)
     input_images = [r['image'] for r in requests]
     loss_meter = AverageMeter()
     
@@ -270,8 +271,10 @@ def execute_multimodal_lora(
         print(20 * "=")
         loss_meter.reset()
 
-        for txt, tgt in zip(
-                chunks(prompts, hparams.batch_size), chunks(labels, hparams.batch_size)
+        for txt, tgt, imgs in zip(
+                chunks(prompts, hparams.batch_size),
+                chunks(labels, hparams.batch_size),
+                chunks(input_images, hparams.batch_size),
         ):
             mask_token = -100
             opt.zero_grad()
@@ -290,15 +293,13 @@ def execute_multimodal_lora(
                                         ],
                                                         add_generation_prompt=True,
                                                         tokenize=False) + l
-                                    for p, l in zip(prompts, labels)]
+                                    for p, l in zip(txt, tgt)]
                     
                 elif file_type in ["image", "single-image", "multi-image"]:
-                    if file_type == "multi-image":
-                        num_images = len(input_images[0])
-                    else:
-                        num_images = 1
-                    
-                    temp_prompt = [processor.apply_chat_template([
+                    temp_prompt = []
+                    for p, l, img in zip(txt, tgt, imgs):
+                        num_images = count_media_items(img, file_type)
+                        temp_prompt.append(processor.apply_chat_template([
                                             {
 
                                                 "role": "user",
@@ -306,25 +307,19 @@ def execute_multimodal_lora(
                                             },
                                         ],
                                                         add_generation_prompt=True,
-                                                        tokenize=False)  + l
-                                    for p, l in zip(prompts, labels)]              
+                                                        tokenize=False) + l)
                 else:
                     raise AssertionError("Not support file type: {}".format(file_type))
                 
                 full_prompt = temp_prompt
                 if file_type in ["image", "single-image", "multi-image"]:
-                    multimodal_inputs = processor(images=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
+                    multimodal_inputs = processor(images=imgs, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
                 elif file_type == "video":
-                    multimodal_inputs = processor(videos=input_images[0], text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
+                    multimodal_inputs = processor(videos=imgs, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=torch.float32)
                     
                 tokens = multimodal_inputs
-                            
-            targets = processor.tokenizer(labels[0], add_special_tokens=False,
-                     return_tensors="pt", padding=True, max_length=multimodal_inputs["input_ids"].size(1))["input_ids"]
-    
-            labels_ids = torch.full_like(multimodal_inputs["input_ids"], -100)
-            labels_ids[:, -targets.size(1):] = targets
-            tokens["labels"] = labels_ids
+
+            tokens["labels"] = build_target_labels(multimodal_inputs["input_ids"], processor.tokenizer, tgt)
             
             tokens = tokens.to(device)
             pred = peft_model(**tokens)

--- a/easyeditor/models/wise/utils.py
+++ b/easyeditor/models/wise/utils.py
@@ -2,6 +2,7 @@ import transformers
 import torch
 import os
 import struct
+from ...util.multimodal import build_target_labels, count_media_items, get_batch_file_type
 
 CONTEXT_TEMPLATES_CACHE = None
 
@@ -145,7 +146,7 @@ def blip2_multimodal_tokenize(batch, processor, device, context_templates=None, 
     prompts = [item['prompt'] for item in batch]   # src
     input_images = [item['image'] for item in batch]
     labels = [item['target'] for item in batch]    # trg
-    file_type = batch[0]['file_type']
+    file_type = get_batch_file_type(batch)
     loc_prompts = [item['locality_prompt'] for item in batch]
     loc_prompts_labels = [item['locality_ground_truth'] for item in batch]
 
@@ -243,11 +244,9 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
     prompts = [item['prompt'] for item in batch]
     input_images = [item['image'] for item in batch]
     labels = [item['target'] for item in batch]
-    file_type = batch[0]['file_type']
+    file_type = get_batch_file_type(batch)
     loc_prompts = [item['locality_prompt'] for item in batch]
     loc_prompts_labels = [item['locality_ground_truth'] for item in batch]
-
-    print(input_images)
 
     mask_token = -100  # ignore_index of CrossEntropyLoss
     if hasattr(hparams, 'use_chat_template') and hparams.use_chat_template:
@@ -281,21 +280,24 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
 
             
         elif file_type in ["image", "single-image", "multi-image"]:
-            if file_type == "multi-image":
-                num_images = len(input_images[0])
-            else:
-                num_images = 1
             if "qwen2-vl" in hparams.model_name.lower():
                 image_token = "<|vision_start|><|image_pad|><|vision_end|>"
-                temp_prompt = [image_token + p + " " + l for p, l in zip(prompts, labels)]
+                chats = [
+                    image_token * count_media_items(img, file_type) + p
+                    for p, img in zip(prompts, input_images)
+                ]
+                temp_prompt = [chat + " " + l for chat, l in zip(chats, labels)]
                 # 事实上此处prompt_ids仅作为计算答案长度用
-                prompt_ids = processor.tokenizer([image_token + p for p in prompts], return_tensors="pt", padding=True, truncation=True)["input_ids"]
+                prompt_ids = processor.tokenizer(chats, return_tensors="pt", padding=True, truncation=True)["input_ids"]
                 # print("temp_prompt: ", temp_prompt)
                 # print("prompt_ids", prompt_ids)
 
 
             else:
-                temp_prompt = [processor.apply_chat_template([
+                chats = []
+                for p, img in zip(prompts, input_images):
+                    num_images = count_media_items(img, file_type)
+                    chats.append(processor.apply_chat_template([
                                         {
 
                                             "role": "user",
@@ -303,20 +305,10 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
                                         },
                                     ],
                                                     add_generation_prompt=True,
-                                                    tokenize=False)  + l
-                                for p, l in zip(prompts, labels)]
+                                                    tokenize=False))
+                temp_prompt = [chat + l for chat, l in zip(chats, labels)]
                 
-                prompt_ids = processor.tokenizer(
-                [processor.apply_chat_template([
-                                {
-
-                                    "role": "user",
-                                    "content": [{"type": "image"}] * num_images + [{"type": "text", "text": p}],
-                                },
-                            ],
-                                        add_generation_prompt=True,
-                                        tokenize=False) for p in prompts], return_tensors="pt", padding=True, truncation=True)["input_ids"]
-            print("prompt with template: ", temp_prompt)     
+                prompt_ids = processor.tokenizer(chats, return_tensors="pt", padding=True, truncation=True)["input_ids"]
         else:
             raise AssertionError("Not support file type: {}".format(file_type))
         
@@ -337,17 +329,19 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
         prompt_ids = processor.tokenizer([f"{templ.format(p)}" for templ in context_templates for p in prompts], return_tensors="pt", padding=True, truncation=True)["input_ids"]
     
     full_prompt = temp_prompt + chat_loc_prompts
-    num_prompt_toks = [len(i) for i in prompt_ids]
-    tokens = processor(text=full_prompt, return_tensors="pt", padding=True, truncation=True)
-    tokens["labels"] = tokens["input_ids"].clone()
 
-    # Mask the tokens based on hparams.objective_optimization
-    if hparams.objective_optimization == 'only_label':
-        for i in range(len(num_prompt_toks)):
-            tokens["labels"][i][:num_prompt_toks[i]] = mask_token
-    
-    # print(tokens["input_ids"])
-    # print(tokens["labels"])
+    if file_type in ["image", "single-image", "multi-image"]:
+        multimodal_inputs = processor(images=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=hparams.dtype)
+    elif file_type == "video":
+        multimodal_inputs = processor(videos=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=hparams.dtype)
+
+    tokens = {
+        key: val
+        for key, val in multimodal_inputs.items()
+        if torch.is_tensor(val)
+    }
+    tokens["labels"] = build_target_labels(tokens["input_ids"], processor.tokenizer, labels + loc_prompts_labels)
+
     act_masks = []
     deact_masks = []
     # Iterate through each batch entry and compute act_mask, deact_mask
@@ -363,9 +357,10 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
                 if start_idx is None:
                     start_idx = find_sublist_start_index(token.detach().cpu().numpy().tolist(), subject_token1)
                     subject_length = len(subject_token1)
-                act_mask[j][start_idx: start_idx + subject_length] = 1
-                deact_mask[j][:start_idx] = 1
-                deact_mask[j][start_idx + subject_length:] = 1
+                if start_idx is not None:
+                    act_mask[j][start_idx: start_idx + subject_length] = 1
+                    deact_mask[j][:start_idx] = 1
+                    deact_mask[j][start_idx + subject_length:] = 1
         else:  # General Editing
             act_mask = None
             deact_mask = None
@@ -380,14 +375,11 @@ def multimodal_tokenize(batch, processor, device, context_templates=None, hparam
 
     tokens = {key: val.to(device) for key, val in tokens.items()}
 
-    if file_type in ["image", "single-image", "multi-image"]:
-        multimodal_inputs = processor(images=input_images, text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=hparams.dtype)
-    elif file_type == "video":
-        multimodal_inputs = processor(videos=input_images[0], text=full_prompt, return_tensors="pt", padding=True).to(device, dtype=hparams.dtype)
-        
-    last_prompt_token_loc = (tokens["labels"] == -100).sum(dim=-1)[0]
-    last_ans_token_loc = (tokens["labels"] == processor.tokenizer.pad_token_id).sum(dim=-1)[0]
-    ans_token_len = len(tokens["labels"][0]) - last_prompt_token_loc - last_ans_token_loc
+    target_tokens = processor.tokenizer(labels, add_special_tokens=False, return_tensors="pt", padding=True)
+    target_mask = target_tokens.get("attention_mask")
+    if target_mask is None:
+        target_mask = torch.ones_like(target_tokens["input_ids"])
+    ans_token_len = target_mask.sum(dim=-1).max().to(device)
     # print(last_prompt_token_loc, last_ans_token_loc, ans_token_len)
     
     return multimodal_inputs, tokens, ans_token_len, act_masks, deact_masks
@@ -464,4 +456,3 @@ def get_context_templates(model, tok, length_params, device):
         # print(f"Cached context templates {CONTEXT_TEMPLATES_CACHE}")
 
     return CONTEXT_TEMPLATES_CACHE
-

--- a/easyeditor/util/alg_dict.py
+++ b/easyeditor/util/alg_dict.py
@@ -54,6 +54,19 @@ ALG_DICT = {
     "SimIE": apply_simie_to_model
 }
 
+MULTIMODAL_EDIT_ALGS = {
+    'MEND',
+    'SERAC',
+    'SERAC_MULTI',
+    'IKE',
+    'LoRA',
+    'WISE',
+    'GRACE',
+}
+
+# Multimodal edit entry points. This is intentionally broader than the
+# multimodal training registry in alg_train_dict.py: several methods support
+# applying edits/evaluation only, but do not expose a trainer implementation.
 ALG_MULTIMODAL_DICT = {
     'MEND': MendMultimodalRewriteExecutor().apply_to_model,
     'SERAC': SeracMultimodalRewriteExecutor().apply_to_model,

--- a/easyeditor/util/alg_train_dict.py
+++ b/easyeditor/util/alg_train_dict.py
@@ -3,6 +3,14 @@ from ..trainer import SERAC, SERAC_MULTI
 from ..trainer import MALMEN
 
 
+# Trainer-backed algorithms. Multimodal edit-only algorithms such as IKE,
+# LoRA, WISE, and GRACE are registered in ALG_MULTIMODAL_DICT instead.
+MULTIMODAL_TRAIN_ALGS = {
+    'MEND',
+    'SERAC',
+    'SERAC_MULTI',
+}
+
 ALG_TRAIN_DICT = {
     'MEND': MEND,
     'SERAC': SERAC,

--- a/easyeditor/util/multimodal.py
+++ b/easyeditor/util/multimodal.py
@@ -1,0 +1,57 @@
+from typing import Sequence
+
+import torch
+
+
+def get_batch_file_type(batch: Sequence[dict]) -> str:
+    file_types = [item["file_type"] for item in batch]
+    first_file_type = file_types[0]
+    if any(file_type != first_file_type for file_type in file_types):
+        raise ValueError(
+            "Mixed file_type values in one multimodal batch are not supported: "
+            f"{file_types}"
+        )
+    return first_file_type
+
+
+def count_media_items(media_item, file_type: str) -> int:
+    if file_type == "multi-image" and isinstance(media_item, list):
+        return len(media_item)
+    return 1
+
+
+def build_target_labels(input_ids: torch.Tensor, tokenizer, targets: Sequence[str]) -> torch.Tensor:
+    target_tokens = tokenizer(
+        list(targets),
+        add_special_tokens=False,
+        return_tensors="pt",
+        padding=True,
+    )
+    target_ids = target_tokens["input_ids"].to(input_ids.device)
+    target_mask = target_tokens.get("attention_mask")
+    if target_mask is None:
+        target_mask = torch.ones_like(target_ids)
+    target_mask = target_mask.to(input_ids.device).bool()
+
+    labels = torch.full_like(input_ids, -100)
+    for row_idx in range(input_ids.size(0)):
+        valid_target = target_ids[row_idx][target_mask[row_idx]]
+        if valid_target.numel() == 0:
+            continue
+        valid_target = valid_target[-input_ids.size(1):]
+        labels[row_idx, -valid_target.numel():] = valid_target
+    return labels
+
+
+def topk_token_match(pre_logits, post_logits, k: int) -> torch.Tensor:
+    pre_logits = torch.as_tensor(pre_logits).to(torch.float32)
+    post_logits = torch.as_tensor(post_logits).to(torch.float32)
+
+    if post_logits.shape[1] > pre_logits.shape[1]:
+        post_logits = post_logits[:, -pre_logits.shape[1]:, :]
+    else:
+        pre_logits = pre_logits[:, -post_logits.shape[1]:, :]
+
+    pre_topk = torch.topk(torch.nn.functional.softmax(pre_logits, dim=-1), k=k, dim=-1).indices
+    post_topk = torch.topk(torch.nn.functional.softmax(post_logits, dim=-1), k=k, dim=-1).indices
+    return (post_topk.reshape(-1) == pre_topk.reshape(-1)).float().mean()


### PR DESCRIPTION
What changed:

  - Fixed LoRA multimodal batch handling so prompts, targets, and images are sliced consistently per batch.
  - Fixed GRACE multimodal label alignment so each sample uses its own target instead of broadcasting labels[0].
  - Fixed WISE multimodal file type and media handling for image/video batches.
  - Unified multimodal locality metric calculation across edit entry points using top-k token matching.
  - Added explicit registry boundaries for multimodal edit algorithms vs trainer-backed algorithms.
  - Fixed WISE Qwen-VL multimodal activation masks by building masks from real multimodal input_ids, including
    visual tokens.

  Tests:

  - Verified LoRA with Qwen3-VL through normal MultimodalEditor.edit() flow, including adapter injection, one
    training step, backward/update, and post evaluation.

  - Verified GRACE with Qwen3-VL through normal edit flow.
  - Verified WISE with Qwen3-VL through normal edit flow after fixing activation mask alignment.
  - Verified WISE multimodal tokenization produces masks aligned with multimodal sequence length.
  - Verified syntax with py_compile.

  Result:

  - LoRA, GRACE, and WISE multimodal editing paths run successfully with Qwen3-VL.
  - Batch label alignment no longer uses the first label for every sample.
  - Locality metrics are now comparable across multimodal edit paths.
  - WISE no longer fails from text-only mask length mismatching visual-token-aware hidden states.