### PR TITLE
fix ike_hparams loading

### DIFF
--- a/easyeditor/models/ike/ike_hparams.py
+++ b/easyeditor/models/ike/ike_hparams.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import List, Optional
 import yaml
 
@@ -40,6 +40,7 @@ class IKEMultimodalHyperParams(HyperParams):
     # Method
     k: int # K icl examples
     results_dir: str
+    template: str
 
     # Module templates
     device: int
@@ -49,6 +50,8 @@ class IKEMultimodalHyperParams(HyperParams):
     tokenizer_class: str
     tokenizer_name: str
     sentence_model_name: str
+    model_parallel: bool
+    use_chat_template: bool
 
     ## Multimodal
     task_name: str
@@ -58,7 +61,7 @@ class IKEMultimodalHyperParams(HyperParams):
     
     # Image_dir
     coco_image: str
-    rephrase_image: str  
+    rephrase_image: str
     exact_match: bool = False
     pretrained_ckpt: Optional[str] = None  
     
@@ -74,4 +77,32 @@ class IKEMultimodalHyperParams(HyperParams):
 
         assert (config and config['alg_name'] == 'IKE') or print(f'IKEMultimodalHyperParams can not load from {hparams_name_or_path}, '
                                                 f'alg_name is {config["alg_name"]} ')
+        defaults = {
+            "k": 16,
+            "results_dir": "./results",
+            "template": "New Fact: {prompt} {target}\nPrompt: {prompt}\n\n",
+            "device": 0,
+            "name": config.get("model_name", "."),
+            "tokenizer_class": ".",
+            "tokenizer_name": ".",
+            "sentence_model_name": "./hugging_cache/all-MiniLM-L6-v2",
+            "model_parallel": False,
+            "use_chat_template": True,
+            "task_name": "multimodal",
+            "qformer_checkpoint": ".",
+            "qformer_name_or_path": ".",
+            "state_dict_file": ".",
+            "coco_image": ".",
+            "rephrase_image": ".",
+        }
+        for key, value in defaults.items():
+            config.setdefault(key, value)
+
+        allowed_keys = {field.name for field in fields(cls)}
+        unexpected_keys = sorted(set(config) - allowed_keys)
+        if unexpected_keys:
+            raise ValueError(
+                "Unexpected IKEMultimodalHyperParams keys in "
+                f"{hparams_name_or_path}: {unexpected_keys}"
+            )
         return cls(**config)

--- a/easyeditor/models/ike/ike_hparams.py
+++ b/easyeditor/models/ike/ike_hparams.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import List, Optional
 import yaml
 
@@ -38,30 +38,30 @@ class IKEHyperParams(HyperParams):
 @dataclass
 class IKEMultimodalHyperParams(HyperParams):
     # Method
-    k: int # K icl examples
-    results_dir: str
-    template: str
+    k: int = 16 # K icl examples
+    results_dir: str = "./results"
+    template: str = "New Fact: {prompt} {target}\nPrompt: {prompt}\n\n"
 
     # Module templates
-    device: int
-    name: str
-    alg_name: str
-    model_name: str
-    tokenizer_class: str
-    tokenizer_name: str
-    sentence_model_name: str
-    model_parallel: bool
-    use_chat_template: bool
+    device: int = 0
+    name: str = "."
+    alg_name: str = "IKE"
+    model_name: str = "."
+    tokenizer_class: str = "."
+    tokenizer_name: str = "."
+    sentence_model_name: str = "./hugging_cache/all-MiniLM-L6-v2"
+    model_parallel: bool = False
+    use_chat_template: bool = True
 
     ## Multimodal
-    task_name: str
-    qformer_checkpoint: str
-    qformer_name_or_path: str
-    state_dict_file: str
+    task_name: str = "multimodal"
+    qformer_checkpoint: str = "."
+    qformer_name_or_path: str = "."
+    state_dict_file: str = "."
     
     # Image_dir
-    coco_image: str
-    rephrase_image: str
+    coco_image: str = "."
+    rephrase_image: str = "."
     exact_match: bool = False
     pretrained_ckpt: Optional[str] = None  
     
@@ -77,32 +77,4 @@ class IKEMultimodalHyperParams(HyperParams):
 
         assert (config and config['alg_name'] == 'IKE') or print(f'IKEMultimodalHyperParams can not load from {hparams_name_or_path}, '
                                                 f'alg_name is {config["alg_name"]} ')
-        defaults = {
-            "k": 16,
-            "results_dir": "./results",
-            "template": "New Fact: {prompt} {target}\nPrompt: {prompt}\n\n",
-            "device": 0,
-            "name": config.get("model_name", "."),
-            "tokenizer_class": ".",
-            "tokenizer_name": ".",
-            "sentence_model_name": "./hugging_cache/all-MiniLM-L6-v2",
-            "model_parallel": False,
-            "use_chat_template": True,
-            "task_name": "multimodal",
-            "qformer_checkpoint": ".",
-            "qformer_name_or_path": ".",
-            "state_dict_file": ".",
-            "coco_image": ".",
-            "rephrase_image": ".",
-        }
-        for key, value in defaults.items():
-            config.setdefault(key, value)
-
-        allowed_keys = {field.name for field in fields(cls)}
-        unexpected_keys = sorted(set(config) - allowed_keys)
-        if unexpected_keys:
-            raise ValueError(
-                "Unexpected IKEMultimodalHyperParams keys in "
-                f"{hparams_name_or_path}: {unexpected_keys}"
-            )
         return cls(**config)


### PR DESCRIPTION
This PR fixes multimodal post-merge compatibility issues around Qwen-VL utilities and IKE hparams loading.
Fixed IKEMultimodalHyperParams.from_hparams() so compact Qwen-VL IKE configs can load correctly.
      - Missing legacy multimodal fields are filled during hparams loading.
      - name defaults to model_name.
      - model_parallel, use_chat_template, and template are explicitly supported.
      - Unknown hparams keys now raise a clear ValueError.
Validation

  - Verified hparams loading for hparams/IKE/qwen3vl_4b.yaml.
  - Ran real-model multimodal editing smoke tests with Qwen3-VL-4B:
      - IKE: OK
      - LoRA: OK
      - GRACE: OK
      - WISE: OK

  - Ran real-model multimodal editing smoke tests with Qwen3.5-9B:
      - IKE: OK
      - LoRA: OK
      - GRACE: OK
      - WISE: OK