### PR TITLE
Fix generated evaluation consistency and preserve locality evidence

### DIFF
--- a/easyeditor/editors/concept_editor.py
+++ b/easyeditor/editors/concept_editor.py
@@ -237,8 +237,6 @@ class ConceptEditor:
                         f"locality.{locality_key}",
                         build_locality_metric_meta(locality_key, self.hparams, self.model_name),
                     )
-                    all_metrics[i]['post']['locality'].pop(f'{locality_key}_output')
-                all_metrics[i]['pre'].pop('locality')
 
             LOG.info(f"Evaluation took {time() - start}")
 

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -51,6 +51,55 @@ def seed_everything(seed):
     random.seed(seed)
     
 seed_everything(42)
+
+
+def finalize_locality_metrics(metric, request, hparams, model_name):
+    if not request.get("locality"):
+        return
+
+    pre_locality = metric["pre"]["locality"]
+    post_locality = metric["post"]["locality"]
+    evaluation_type = getattr(hparams, "evaluation_type", None)
+    uses_generated_text = evaluation_type in ["LLM-judge", "generate-text"]
+
+    for locality_key in request["locality"]:
+        if uses_generated_text:
+            output_key = f"{locality_key}_gen_content"
+        else:
+            output_key = f"{locality_key}_output"
+
+        pre_outputs = pre_locality[output_key]
+        post_outputs = post_locality[output_key]
+        if len(pre_outputs) != len(post_outputs):
+            raise ValueError(
+                f"Locality output count mismatch for `{locality_key}`: "
+                f"{len(pre_outputs)} pre-edit outputs and "
+                f"{len(post_outputs)} post-edit outputs."
+            )
+
+        if uses_generated_text:
+            locality_result = [
+                float(pre_output == post_output)
+                for pre_output, post_output in zip(pre_outputs, post_outputs)
+            ]
+        else:
+            locality_result = [
+                float(np.mean(np.equal(pre_output, post_output)))
+                for pre_output, post_output in zip(pre_outputs, post_outputs)
+            ]
+
+        post_locality[f"{locality_key}_acc"] = locality_result
+        attach_metric_meta(
+            metric["post"],
+            f"locality.{locality_key}",
+            build_locality_metric_meta(locality_key, hparams, model_name),
+        )
+
+        if not uses_generated_text:
+            post_locality.pop(output_key)
+
+    if not uses_generated_text:
+        metric["pre"].pop("locality")
   
 class BaseEditor:
     """Base editor for all methods"""
@@ -252,22 +301,12 @@ class BaseEditor:
                 restore_after_edit(self, edited_model, weights_copy)
 
             for i, request in enumerate(record_chunks):
-                if 'locality' in chunk_metrics[i]['post'].keys():
-                    for locality_key in request['locality'].keys():
-                        locality_result = []
-                        if hasattr(self.hparams, 'evaluation_type') and self.hparams.evaluation_type == "LLM-judge":
-                            locality_result.append(float(chunk_metrics[i]['post']['locality'][f'{locality_key}_output']==chunk_metrics[i]['pre']['locality'][f'{locality_key}_output']))
-                        else:
-                            for ans, label in zip(chunk_metrics[i]['post']['locality'][f'{locality_key}_output'], chunk_metrics[i]['pre']['locality'][f'{locality_key}_output']):
-                                locality_result.append(np.mean(np.equal(ans, label)))
-                        chunk_metrics[i]['post']['locality'][f'{locality_key}_acc'] = locality_result
-                        attach_metric_meta(
-                            chunk_metrics[i]['post'],
-                            f"locality.{locality_key}",
-                            build_locality_metric_meta(locality_key, self.hparams, self.model_name),
-                        )
-                        chunk_metrics[i]['post']['locality'].pop(f'{locality_key}_output')
-                    chunk_metrics[i]['pre'].pop('locality')
+                finalize_locality_metrics(
+                    chunk_metrics[i],
+                    request,
+                    self.hparams,
+                    self.model_name,
+                )
 
                 if verbose:
                     LOG.info(
@@ -356,22 +395,12 @@ class BaseEditor:
                 })
                 if "metric_kwargs" in kwargs:
                     all_metrics[idx].update(compute_sent_metric(self.model, edited_model, self.model_name, self.hparams, self.tok,metric_kwargs=kwargs["metric_kwargs"][idx], device=self.hparams.device))
-                if 'locality' in all_metrics[idx]['post'].keys() and not hasattr(self.hparams, 'evaluation_type'):
-                    for locality_key in request['locality'].keys():
-                        locality_result = []
-                        if hasattr(self.hparams, 'evaluation_type'):
-                            locality_result.append(float(all_metrics[idx]['post']['locality'][f'{locality_key}_output']==all_metrics[idx]['pre']['locality'][f'{locality_key}_output']))
-                        else:
-                            for ans, label in zip(all_metrics[idx]['post']['locality'][f'{locality_key}_output'], all_metrics[idx]['pre']['locality'][f'{locality_key}_output']):
-                                locality_result.append(np.mean(np.equal(ans, label)))
-                        all_metrics[idx]['post']['locality'][f'{locality_key}_acc'] = locality_result
-                        attach_metric_meta(
-                            all_metrics[idx]['post'],
-                            f"locality.{locality_key}",
-                            build_locality_metric_meta(locality_key, self.hparams, self.model_name),
-                        )
-                        all_metrics[idx]['post']['locality'].pop(f'{locality_key}_output')
-                    all_metrics[idx]['pre'].pop('locality')
+                finalize_locality_metrics(
+                    all_metrics[idx],
+                    request,
+                    self.hparams,
+                    self.model_name,
+                )
 
             if verbose:
                 LOG.info(f"{idx} editing: {request['prompt']} -> {request['target_new']}  \n\n {all_metrics[idx]}")
@@ -395,8 +424,7 @@ class BaseEditor:
 
         if isinstance(edited_model, LORA):
             edited_model = edited_model.model
-        if not hasattr(self.hparams, 'evaluation_type') or self.hparams.evaluation_type != "generate-text":
-            summary_metrics(all_metrics)
+        summary_metrics(all_metrics)
 
         return all_metrics, edited_model, weights_copy
 

--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -94,12 +94,6 @@ def finalize_locality_metrics(metric, request, hparams, model_name):
             f"locality.{locality_key}",
             build_locality_metric_meta(locality_key, hparams, model_name),
         )
-
-        if not uses_generated_text:
-            post_locality.pop(output_key)
-
-    if not uses_generated_text:
-        metric["pre"].pop("locality")
   
 class BaseEditor:
     """Base editor for all methods"""

--- a/easyeditor/editors/multimodal_editor.py
+++ b/easyeditor/editors/multimodal_editor.py
@@ -53,10 +53,42 @@ def make_logs():
     LOG.addHandler(s_h)
 
 
+def get_aligned_topk_token_ids(pre_logits, post_logits, k):
+    pre_logits = torch.as_tensor(pre_logits)
+    post_logits = torch.as_tensor(post_logits)
+    if pre_logits.dim() != 3 or post_logits.dim() != 3:
+        raise ValueError(
+            "pre_logits and post_logits must be rank-3 tensors shaped "
+            "[batch, sequence, vocab]."
+        )
+    if pre_logits.shape[0] != post_logits.shape[0]:
+        raise ValueError(
+            "pre_logits and post_logits must have the same batch size: "
+            f"{pre_logits.shape[0]} != {post_logits.shape[0]}"
+        )
+
+    if post_logits.shape[1] > pre_logits.shape[1]:
+        post_logits = post_logits[:, -pre_logits.shape[1]:, :]
+    else:
+        pre_logits = pre_logits[:, -post_logits.shape[1]:, :]
+
+    k = min(k, pre_logits.shape[-1], post_logits.shape[-1])
+    pre_topk = torch.topk(pre_logits, k=k, dim=-1).indices.cpu().tolist()
+    post_topk = torch.topk(post_logits, k=k, dim=-1).indices.cpu().tolist()
+    return pre_topk, post_topk
+
+
 def attach_topk_locality_metrics(metrics):
     if 'locality_output' in metrics['post'].keys():
         assert len(metrics['post']['locality_output']) == \
                 len(metrics['pre']['locality_output'])
+        pre_topk, post_topk = get_aligned_topk_token_ids(
+            metrics['pre']['locality_output'],
+            metrics['post']['locality_output'],
+            k=1,
+        )
+        metrics['pre']['locality_topk_tokens'] = pre_topk
+        metrics['post']['locality_topk_tokens'] = post_topk
         metrics['post']['locality_acc'] = topk_token_match(
             metrics['pre']['locality_output'],
             metrics['post']['locality_output'],
@@ -78,6 +110,13 @@ def attach_topk_locality_metrics(metrics):
     if 'multimodal_locality_output' in metrics['post'].keys():
         assert len(metrics['post']['multimodal_locality_output']) == \
                 len(metrics['pre']['multimodal_locality_output'])
+        pre_topk, post_topk = get_aligned_topk_token_ids(
+            metrics['pre']['multimodal_locality_output'],
+            metrics['post']['multimodal_locality_output'],
+            k=10,
+        )
+        metrics['pre']['multimodal_locality_topk_tokens'] = pre_topk
+        metrics['post']['multimodal_locality_topk_tokens'] = post_topk
         metrics['post']['multimodal_locality_acc'] = topk_token_match(
             metrics['pre']['multimodal_locality_output'],
             metrics['post']['multimodal_locality_output'],

--- a/easyeditor/evaluate/evaluate.py
+++ b/easyeditor/evaluate/evaluate.py
@@ -16,6 +16,7 @@ from transformers import AutoTokenizer
 from ..util import HyperParams
 from ..util.device import normalize_device
 from .evaluate_utils import (
+    generate_texts,
     test_seq2seq_batch_prediction_acc, 
     test_batch_prediction_acc, 
     test_prediction_acc,
@@ -126,7 +127,7 @@ def compute_rewrite_or_rephrase_quality(
             f"{key}_gen_content": gen_content
         }
     elif hasattr(hparams, 'evaluation_type') and hparams.evaluation_type == "generate-text":
-        gen_content_model = test_prediction_acc_LLM_judge(model, tok, hparams, prompt, target_new, device, locality=False)
+        gen_content_model = generate_texts(model, tok, hparams, prompt, device)
         ret = {
             f"{key}_gen_content": gen_content_model
         }
@@ -176,8 +177,13 @@ def compute_locality_quality(
 ) -> typing.Dict:
 
     # using real-world evaluation: autoregressive decoding, natural stop criteria, LLM-as-a-Judge
-    if hasattr(hparams, 'evaluation_type'):
-        loc_tokens = test_prediction_acc_LLM_judge(model, tok, hparams, prompt, locality_ground_truth, device, locality=True)
+    evaluation_type = getattr(hparams, "evaluation_type", None)
+    if evaluation_type in ["LLM-judge", "generate-text"]:
+        return {
+            f"{locality_key}_gen_content": generate_texts(
+                model, tok, hparams, prompt, device
+            )
+        }
     else:  # traditional evaluation 
         if 't5' in model_name.lower():
             loc_tokens = test_seq2seq_batch_prediction_acc(model, tok, hparams, prompt, locality_ground_truth, device, locality=True)
@@ -202,10 +208,21 @@ def compute_portability_quality(
     device,
 ) -> typing.Dict:
     # using real-world evaluation: autoregressive decoding, natural stop criteria, LLM-as-a-Judge
-    if hasattr(hparams, 'evaluation_type') and hparams.evaluation_type == "LLM-judge":
-        portability_correct = test_prediction_acc_LLM_judge(model, tok, hparams, prompt, ground_truth, device, locality=False)
-    elif hasattr(hparams, 'evaluation_type') and hparams.evaluation_type == "generate-text":
-        portability_correct = test_prediction_acc_LLM_judge(model, tok, hparams, prompt, ground_truth, device, locality=False)
+    evaluation_type = getattr(hparams, "evaluation_type", None)
+    if evaluation_type == "LLM-judge":
+        portability_correct, gen_content = test_prediction_acc_LLM_judge(
+            model, tok, hparams, prompt, ground_truth, device, locality=False
+        )
+        return {
+            f"{portability_key}_acc": portability_correct,
+            f"{portability_key}_gen_content": gen_content,
+        }
+    elif evaluation_type == "generate-text":
+        return {
+            f"{portability_key}_gen_content": generate_texts(
+                model, tok, hparams, prompt, device
+            )
+        }
     else:  # traditional evaluation
         if 't5' in model_name.lower():
             portability_correct = test_seq2seq_batch_prediction_acc(model, tok, hparams, prompt, ground_truth, device)

--- a/easyeditor/evaluate/evaluate_utils.py
+++ b/easyeditor/evaluate/evaluate_utils.py
@@ -101,12 +101,11 @@ Just return the letters "A" or "B", with no text around it.
     time.sleep(1) # avoid high rate of request
     return llm_score
 
-def test_prediction_acc_LLM_judge(model, tok, hparams, prompts, targets, device, locality=False):
-    # generation & truncation
-    all_score = []
-    all_response = []
+def generate_texts(model, tok, hparams, prompts, device):
     if isinstance(prompts, str):
-        prompts, targets = [prompts, ], [targets, ]
+        prompts = [prompts]
+
+    all_response = []
     for prompt in prompts:
         messages = [
                 {"role": "system", "content": "You are a helpful assistant."},
@@ -146,25 +145,32 @@ def test_prediction_acc_LLM_judge(model, tok, hparams, prompts, targets, device,
         gen_content = tok.decode(trunc_gen_tokens)
         suffixes_to_remove = [".", "\n", tok.eos_token]
         for suffix in suffixes_to_remove:
-            if gen_content.endswith(suffix):
+            if suffix and gen_content.endswith(suffix):
                 gen_content = gen_content[:-len(suffix)]
-        # LLM-as-a-Judge
-        if hparams.evaluation_type == "generate-text":
-            all_response.append(gen_content)
-        elif hparams.evaluation_type == "LLM-judge" and hasattr(hparams, 'api_key') and hparams.api_key:
-            LLM_Score = llm_judge(prompts, targets, gen_content, hparams.api_key)
-            all_score.append(LLM_Score)
-            all_response.append(gen_content)
+
+        all_response.append(gen_content)
+
+    return all_response
+
+
+def test_prediction_acc_LLM_judge(model, tok, hparams, prompts, targets, device, locality=False):
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if isinstance(targets, str):
+        targets = [targets]
+    if len(prompts) != len(targets):
+        raise ValueError("The number of prompts and targets must match.")
+
+    all_response = generate_texts(model, tok, hparams, prompts, device)
+    all_score = []
+    for prompt, target, gen_content in zip(prompts, targets, all_response):
+        if hasattr(hparams, 'api_key') and hparams.api_key:
+            score = llm_judge(prompt, target, gen_content, hparams.api_key)
         else:
-            # the user do not provide api key, using exact match as an alternative
-            EM_Score = float(exact_match_score(gen_content, targets))
-            all_score.append(EM_Score)
-            all_response.append(gen_content)
-    
-    if len(all_score) > 0:
-        return all_score, all_response
-    else:
-        return all_response
+            score = float(exact_match_score(gen_content, target))
+        all_score.append(score)
+
+    return all_score, all_response
 
 def test_batch_prediction_acc(model, tok, hparams, prompts, target, device, locality=False):
     prompt_tok = tok(


### PR DESCRIPTION
## Summary

This PR fixes two evaluation issues:

1. `generate-text` and `LLM-judge` previously returned inconsistent result structures, which could mix generated text with numeric accuracy fields.
2. Locality post-processing removed the original pre/post outputs after computing `locality_acc`, preventing users from auditing how the score was produced.

## Changes

### Generated evaluation result consistency

- Separate raw text generation from judge scoring.
- Make the judge helper consistently return scores and generated text.
- Store numeric values only in `*_acc`.
- Store generated text only in `*_gen_content`.
- Fix rewrite, rephrase, portability, and locality result structures.
- Use the same locality post-processing for `edit()` and `batch_edit()`.
- Allow `generate-text` results to pass through `summary_metrics()` safely.

### Locality evidence preservation

- Preserve pre/post token outputs for standard text locality evaluation.
- Preserve pre/post locality outputs in `ConceptEditor`.
- Preserve generated pre/post text for `generate-text` and `LLM-judge`.
- Preserve aligned top-1 token IDs for multimodal text locality.
- Preserve aligned top-10 token IDs for multimodal image locality.
- Continue removing full multimodal logits to avoid excessive result size and JSON serialization problems.
- Keep the existing `locality_acc` calculations unchanged.

## Validation

The full validation script is included below. It covers:

- `compileall`
- `git diff --check`
- source-level result contract checks
- generate-text rewrite/rephrase/portability structures
- LLM-judge fallback score/text separation
- generated-text locality pre/post comparison
- preservation of teacher-forcing pre/post token outputs
- preservation of ConceptEditor locality outputs
- aligned and JSON-serializable multimodal top-k locality evidence
- compatibility with `summary_metrics()`
- real `edit()` and `batch_edit()` smoke tests

The real smoke validation was run with Qwen2.5-1.5B-Instruct and one-step FT. All checks passed:

```text
compileall: pass
git_diff_check: pass
source_result_contract: pass
mock_result_contracts: pass
real_generate_text_edit: pass
real_llm_judge_fallback_batch_edit: pass
real_teacher_forcing_locality_evidence: pass
```

<details>
<summary>Full validation script</summary>

```python
#!/usr/bin/env python3
import argparse
import compileall
import importlib
import json
import os
import subprocess
import sys
import tempfile
from pathlib import Path
from types import SimpleNamespace


REPO_ROOT = Path(__file__).resolve().parents[1]
if str(REPO_ROOT) not in sys.path:
    sys.path.insert(0, str(REPO_ROOT))


CHECK_FILES = [
    "easyeditor/evaluate/evaluate_utils.py",
    "easyeditor/evaluate/evaluate.py",
    "easyeditor/editors/editor.py",
    "easyeditor/editors/concept_editor.py",
    "easyeditor/editors/multimodal_editor.py",
]


def record(results, name, status, detail=None):
    item = {"name": name, "status": status}
    if detail is not None:
        item["detail"] = detail
    results.append(item)


def to_builtin(value):
    if isinstance(value, dict):
        return {key: to_builtin(item) for key, item in value.items()}
    if isinstance(value, (list, tuple)):
        return [to_builtin(item) for item in value]
    if hasattr(value, "item"):
        return value.item()
    return value


def assert_text_list(value, field):
    assert isinstance(value, list), f"{field} must be a list, got {type(value).__name__}"
    assert all(isinstance(item, str) for item in value), (
        f"{field} must contain only strings: {value}"
    )


def assert_numeric_list(value, field):
    assert isinstance(value, list), f"{field} must be a list, got {type(value).__name__}"
    assert all(isinstance(to_builtin(item), (int, float)) for item in value), (
        f"{field} must contain only numbers: {value}"
    )


def run_compileall(results):
    failed = []
    for rel_path in CHECK_FILES:
        if not compileall.compile_file(str(REPO_ROOT / rel_path), quiet=1):
            failed.append(rel_path)
    if failed:
        raise AssertionError(f"compileall failed: {failed}")
    record(results, "compileall", "pass", CHECK_FILES)


def run_diff_check(results):
    proc = subprocess.run(
        ["git", "diff", "--check"],
        cwd=REPO_ROOT,
        text=True,
        stdout=subprocess.PIPE,
        stderr=subprocess.STDOUT,
    )
    if proc.returncode != 0:
        raise AssertionError(proc.stdout)
    record(results, "git_diff_check", "pass")


def run_source_contract_check(results):
    evaluate_utils_source = (
        REPO_ROOT / "easyeditor/evaluate/evaluate_utils.py"
    ).read_text()
    evaluate_source = (REPO_ROOT / "easyeditor/evaluate/evaluate.py").read_text()
    editor_source = (REPO_ROOT / "easyeditor/editors/editor.py").read_text()
    concept_editor_source = (
        REPO_ROOT / "easyeditor/editors/concept_editor.py"
    ).read_text()
    multimodal_editor_source = (
        REPO_ROOT / "easyeditor/editors/multimodal_editor.py"
    ).read_text()

    required_snippets = {
        "evaluate_utils.py": [
            "def generate_texts(",
            "return all_score, all_response",
        ],
        "evaluate.py": [
            'f"{portability_key}_gen_content"',
            'f"{locality_key}_gen_content"',
        ],
        "editor.py": [
            "def finalize_locality_metrics(",
            "summary_metrics(all_metrics)",
        ],
        "multimodal_editor.py": [
            "def get_aligned_topk_token_ids(",
            "locality_topk_tokens",
            "multimodal_locality_topk_tokens",
        ],
    }
    sources = {
        "evaluate_utils.py": evaluate_utils_source,
        "evaluate.py": evaluate_source,
        "editor.py": editor_source,
        "multimodal_editor.py": multimodal_editor_source,
    }
    missing = []
    for filename, snippets in required_snippets.items():
        for snippet in snippets:
            if snippet not in sources[filename]:
                missing.append({"file": filename, "snippet": snippet})
    if missing:
        raise AssertionError(f"missing expected result-contract code: {missing}")

    forbidden_locality_cleanup = {
        "editor.py": [
            'post_locality.pop(output_key)',
            'metric["pre"].pop("locality")',
        ],
        "concept_editor.py": [
            ".pop(f'{locality_key}_output')",
            ".pop('locality')",
        ],
    }
    cleanup_sources = {
        "editor.py": editor_source,
        "concept_editor.py": concept_editor_source,
    }
    cleanup_hits = []
    for filename, snippets in forbidden_locality_cleanup.items():
        for snippet in snippets:
            if snippet in cleanup_sources[filename]:
                cleanup_hits.append({"file": filename, "snippet": snippet})
    if cleanup_hits:
        raise AssertionError(
            f"found locality evidence cleanup code: {cleanup_hits}"
        )

    record(results, "source_result_contract", "pass")


def run_mock_result_contract_checks(results):
    evaluate_module = importlib.import_module("easyeditor.evaluate.evaluate")
    editor_module = importlib.import_module("easyeditor.editors.editor")
    multimodal_editor_module = importlib.import_module(
        "easyeditor.editors.multimodal_editor"
    )
    utils_module = importlib.import_module("easyeditor.editors.utils")
    import torch

    original_generate_texts = evaluate_module.generate_texts
    original_judge = evaluate_module.test_prediction_acc_LLM_judge
    evaluate_module.generate_texts = lambda *args, **kwargs: ["generated answer"]
    evaluate_module.test_prediction_acc_LLM_judge = (
        lambda *args, **kwargs: ([1.0], ["judged answer"])
    )

    generate_hparams = SimpleNamespace(
        evaluation_type="generate-text",
        alg_name="FT",
    )
    judge_hparams = SimpleNamespace(
        evaluation_type="LLM-judge",
        alg_name="FT",
        api_key="mock-key",
    )

    try:
        rewrite_generate = evaluate_module.compute_rewrite_or_rephrase_quality(
            None, "qwen", generate_hparams, None, "prompt", "target", 0
        )
        assert_text_list(
            rewrite_generate["rewrite_gen_content"],
            "rewrite_gen_content",
        )
        assert "rewrite_acc" not in rewrite_generate

        rephrase_generate = evaluate_module.compute_rewrite_or_rephrase_quality(
            None,
            "qwen",
            generate_hparams,
            None,
            "rephrase prompt",
            "target",
            0,
            test_rephrase=True,
        )
        assert_text_list(
            rephrase_generate["rephrase_gen_content"],
            "rephrase_gen_content",
        )
        assert "rephrase_acc" not in rephrase_generate

        rewrite_judge = evaluate_module.compute_rewrite_or_rephrase_quality(
            None, "qwen", judge_hparams, None, "prompt", "target", 0
        )
        assert_numeric_list(rewrite_judge["rewrite_acc"], "rewrite_acc")
        assert_text_list(
            rewrite_judge["rewrite_gen_content"],
            "rewrite_gen_content",
        )

        portability_generate = evaluate_module.compute_portability_quality(
            None,
            "qwen",
            generate_hparams,
            None,
            "one_hop",
            "prompt",
            "target",
            0,
        )
        assert_text_list(
            portability_generate["one_hop_gen_content"],
            "one_hop_gen_content",
        )
        assert "one_hop_acc" not in portability_generate

        portability_judge = evaluate_module.compute_portability_quality(
            None,
            "qwen",
            judge_hparams,
            None,
            "one_hop",
            "prompt",
            "target",
            0,
        )
        assert_numeric_list(
            portability_judge["one_hop_acc"],
            "one_hop_acc",
        )
        assert_text_list(
            portability_judge["one_hop_gen_content"],
            "one_hop_gen_content",
        )

        locality_generate = evaluate_module.compute_locality_quality(
            None,
            "qwen",
            generate_hparams,
            None,
            "neighborhood",
            "prompt",
            "target",
            0,
        )
        assert locality_generate == {
            "neighborhood_gen_content": ["generated answer"]
        }

        request = {"locality": {"neighborhood": {}}}
        same_metric = {
            "pre": {
                "locality": {
                    "neighborhood_gen_content": ["Berlin"],
                }
            },
            "post": {
                "locality": {
                    "neighborhood_gen_content": ["Berlin"],
                }
            },
        }
        editor_module.finalize_locality_metrics(
            same_metric,
            request,
            generate_hparams,
            "qwen",
        )
        assert same_metric["post"]["locality"]["neighborhood_acc"] == [1.0]

        changed_metric = {
            "pre": {
                "locality": {
                    "neighborhood_gen_content": ["Berlin"],
                }
            },
            "post": {
                "locality": {
                    "neighborhood_gen_content": ["Munich"],
                }
            },
        }
        editor_module.finalize_locality_metrics(
            changed_metric,
            request,
            judge_hparams,
            "qwen",
        )
        assert changed_metric["post"]["locality"]["neighborhood_acc"] == [0.0]

        token_metric = {
            "pre": {
                "locality": {
                    "neighborhood_output": [[10, 20]],
                }
            },
            "post": {
                "locality": {
                    "neighborhood_output": [[10, 99]],
                }
            },
        }
        editor_module.finalize_locality_metrics(
            token_metric,
            request,
            SimpleNamespace(alg_name="FT"),
            "qwen",
        )
        assert token_metric["pre"]["locality"][
            "neighborhood_output"
        ] == [[10, 20]]
        assert token_metric["post"]["locality"][
            "neighborhood_output"
        ] == [[10, 99]]
        assert token_metric["post"]["locality"][
            "neighborhood_acc"
        ] == [0.5]

        pre_text_logits = torch.tensor([[
            [0.1, 0.9, 0.2],
            [0.8, 0.1, 0.3],
            [0.2, 0.3, 0.7],
        ]])
        post_text_logits = torch.tensor([[
            [0.8, 0.1, 0.3],
            [0.7, 0.1, 0.2],
        ]])
        pre_image_logits = torch.arange(
            1 * 3 * 12,
            dtype=torch.float32,
        ).reshape(1, 3, 12)
        post_image_logits = pre_image_logits[:, -2:, :].clone()
        multimodal_metric = {
            "pre": {
                "locality_output": pre_text_logits,
                "multimodal_locality_output": pre_image_logits,
            },
            "post": {
                "locality_output": post_text_logits,
                "multimodal_locality_output": post_image_logits,
            },
        }
        multimodal_editor_module.attach_topk_locality_metrics(
            multimodal_metric
        )
        assert "locality_output" not in multimodal_metric["pre"]
        assert "locality_output" not in multimodal_metric["post"]
        assert "multimodal_locality_output" not in multimodal_metric["pre"]
        assert "multimodal_locality_output" not in multimodal_metric["post"]
        assert isinstance(
            multimodal_metric["pre"]["locality_topk_tokens"],
            list,
        )
        assert isinstance(
            multimodal_metric["post"]["locality_topk_tokens"],
            list,
        )
        assert isinstance(
            multimodal_metric["pre"][
                "multimodal_locality_topk_tokens"
            ],
            list,
        )
        assert isinstance(
            multimodal_metric["post"][
                "multimodal_locality_topk_tokens"
            ],
            list,
        )
        json.dumps(to_builtin(multimodal_metric))

        summary_input = [{
            "pre": {
                "rewrite_gen_content": ["before"],
                "locality": {
                    "neighborhood_gen_content": ["Berlin"],
                    "neighborhood_output": [[10, 20]],
                },
            },
            "post": {
                "rewrite_gen_content": ["after"],
                "portability": {
                    "one_hop_gen_content": ["Paris"],
                },
                "locality": {
                    "neighborhood_gen_content": ["Berlin"],
                    "neighborhood_output": [[10, 99]],
                    "neighborhood_acc": [1.0],
                },
            },
        }]
        old_cwd = Path.cwd()
        with tempfile.TemporaryDirectory() as temp_dir:
            os.chdir(temp_dir)
            try:
                utils_module.summary_metrics(summary_input)
            finally:
                os.chdir(old_cwd)
    finally:
        evaluate_module.generate_texts = original_generate_texts
        evaluate_module.test_prediction_acc_LLM_judge = original_judge

    record(
        results,
        "mock_result_contracts",
        "pass",
        {
            "generate_text": "*_gen_content contains text only",
            "llm_judge": "*_acc contains numbers and *_gen_content contains text",
            "locality": "pre/post generated text produces numeric locality_acc",
            "token_locality": "pre/post token outputs remain available",
            "multimodal_locality": "aligned top-k token evidence is JSON serializable",
            "concept_locality": "source no longer removes pre/post locality output",
            "summary": "generated text is ignored by numeric aggregation",
        },
    )


def build_eval_inputs():
    return {
        "prompts": "The internal validation generated evaluation key is",
        "target_new": " alpha",
        "ground_truth": None,
        "rephrase_prompts": "What is the internal generated evaluation key?",
        "locality_inputs": {
            "neighborhood": {
                "prompt": "The capital of France is",
                "ground_truth": " Paris",
            }
        },
        "portability_inputs": {
            "one_hop": {
                "prompt": "The internal generated portability key is",
                "ground_truth": " alpha",
            }
        },
        "sequential_edit": False,
        "verbose": False,
    }


def validate_real_metrics(metrics, mode):
    case = metrics[0]
    pre = case["pre"]
    post = case["post"]

    assert_numeric_list(
        post["locality"]["neighborhood_acc"],
        "post.locality.neighborhood_acc",
    )

    if mode in ["generate-text", "LLM-judge"]:
        for phase_name, phase in [("pre", pre), ("post", post)]:
            assert_text_list(
                phase["rewrite_gen_content"],
                f"{phase_name}.rewrite_gen_content",
            )
            assert_text_list(
                phase["rephrase_gen_content"],
                f"{phase_name}.rephrase_gen_content",
            )
            assert_text_list(
                phase["portability"]["one_hop_gen_content"],
                f"{phase_name}.portability.one_hop_gen_content",
            )
            assert_text_list(
                phase["locality"]["neighborhood_gen_content"],
                f"{phase_name}.locality.neighborhood_gen_content",
            )

    if mode == "generate-text":
        assert "rewrite_acc" not in pre and "rewrite_acc" not in post
        assert "rephrase_acc" not in pre and "rephrase_acc" not in post
        assert "one_hop_acc" not in pre["portability"]
        assert "one_hop_acc" not in post["portability"]
    elif mode == "LLM-judge":
        assert_numeric_list(pre["rewrite_acc"], "pre.rewrite_acc")
        assert_numeric_list(post["rewrite_acc"], "post.rewrite_acc")
        assert_numeric_list(pre["rephrase_acc"], "pre.rephrase_acc")
        assert_numeric_list(post["rephrase_acc"], "post.rephrase_acc")
        assert_numeric_list(
            pre["portability"]["one_hop_acc"],
            "pre.portability.one_hop_acc",
        )
        assert_numeric_list(
            post["portability"]["one_hop_acc"],
            "post.portability.one_hop_acc",
        )
    else:
        assert_numeric_list(pre["rewrite_acc"], "pre.rewrite_acc")
        assert_numeric_list(post["rewrite_acc"], "post.rewrite_acc")
        assert_numeric_list(pre["rephrase_acc"], "pre.rephrase_acc")
        assert_numeric_list(post["rephrase_acc"], "post.rephrase_acc")
        assert_numeric_list(
            pre["portability"]["one_hop_acc"],
            "pre.portability.one_hop_acc",
        )
        assert_numeric_list(
            post["portability"]["one_hop_acc"],
            "post.portability.one_hop_acc",
        )
        pre_output = pre["locality"]["neighborhood_output"]
        post_output = post["locality"]["neighborhood_output"]
        assert isinstance(pre_output, list), pre_output
        assert isinstance(post_output, list), post_output

    return {
        "mode": mode,
        "pre": {
            "rewrite_keys": sorted(
                key for key in pre if key.startswith("rewrite_")
            ),
            "rephrase_keys": sorted(
                key for key in pre if key.startswith("rephrase_")
            ),
            "portability_keys": sorted(pre["portability"]),
            "locality_keys": sorted(pre["locality"]),
            "locality_evidence": to_builtin(
                pre["locality"].get(
                    "neighborhood_gen_content",
                    pre["locality"].get("neighborhood_output"),
                )
            ),
        },
        "post": {
            "rewrite_keys": sorted(
                key for key in post if key.startswith("rewrite_")
            ),
            "rephrase_keys": sorted(
                key for key in post if key.startswith("rephrase_")
            ),
            "portability_keys": sorted(post["portability"]),
            "locality_keys": sorted(post["locality"]),
            "locality_acc": to_builtin(
                post["locality"]["neighborhood_acc"]
            ),
            "locality_evidence": to_builtin(
                post["locality"].get(
                    "neighborhood_gen_content",
                    post["locality"].get("neighborhood_output"),
                )
            ),
        },
    }


def run_model_smoke(results, args):
    from easyeditor import BaseEditor, FTHyperParams

    hparams = FTHyperParams.from_hparams(args.hparams)
    hparams.model_name = args.model
    hparams.device = args.device
    hparams.layers = [args.layer]
    hparams.num_steps = args.num_steps
    hparams.batch_size = 1

    editor = BaseEditor.from_hparams(hparams)

    hparams.evaluation_type = "generate-text"
    hparams.api_key = ""
    generate_metrics, _, _ = editor.edit(**build_eval_inputs())
    generate_detail = validate_real_metrics(
        generate_metrics,
        "generate-text",
    )
    record(
        results,
        "real_generate_text_edit",
        "pass",
        generate_detail,
    )

    hparams.evaluation_type = "LLM-judge"
    hparams.api_key = ""
    batch_inputs = build_eval_inputs()
    batch_inputs["prompts"] = [batch_inputs["prompts"]]
    batch_inputs["target_new"] = [batch_inputs["target_new"]]
    batch_inputs["ground_truth"] = [None]
    batch_inputs["rephrase_prompts"] = [batch_inputs["rephrase_prompts"]]
    for section in ["locality_inputs", "portability_inputs"]:
        for item in batch_inputs[section].values():
            item["prompt"] = [item["prompt"]]
            item["ground_truth"] = [item["ground_truth"]]

    judge_metrics, _, _ = editor.batch_edit(**batch_inputs)
    judge_detail = validate_real_metrics(
        judge_metrics,
        "LLM-judge",
    )
    record(
        results,
        "real_llm_judge_fallback_batch_edit",
        "pass",
        judge_detail,
    )

    if hasattr(hparams, "evaluation_type"):
        delattr(hparams, "evaluation_type")
    if hasattr(hparams, "api_key"):
        delattr(hparams, "api_key")
    token_metrics, _, _ = editor.edit(**build_eval_inputs())
    token_detail = validate_real_metrics(
        token_metrics,
        "teacher-forcing",
    )
    record(
        results,
        "real_teacher_forcing_locality_evidence",
        "pass",
        token_detail,
    )


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--model", default=os.environ.get("MODEL"))
    parser.add_argument("--hparams", default="hparams/FT/qwen2.5-7b.yaml")
    parser.add_argument("--device", type=int, default=0)
    parser.add_argument("--layer", type=int, default=0)
    parser.add_argument("--num-steps", type=int, default=1)
    parser.add_argument(
        "--out",
        default="outputs/generated_evaluation_consistency_validation.json",
    )
    parser.add_argument(
        "--skip-model-smoke",
        action="store_true",
        help="Run only static and mock checks.",
    )
    args = parser.parse_args()

    results = []
    run_compileall(results)
    run_diff_check(results)
    run_source_contract_check(results)
    run_mock_result_contract_checks(results)

    if args.skip_model_smoke or not args.model:
        record(
            results,
            "real_model_smoke",
            "skipped",
            "Pass --model or set MODEL to run real Qwen validation.",
        )
    else:
        run_model_smoke(results, args)

    payload = {
        "repo": str(REPO_ROOT),
        "commit": subprocess.check_output(
            ["git", "rev-parse", "--short", "HEAD"],
            cwd=REPO_ROOT,
            text=True,
        ).strip(),
        "results": to_builtin(results),
    }

    out_path = REPO_ROOT / args.out
    out_path.parent.mkdir(parents=True, exist_ok=True)
    out_path.write_text(
        json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
    )
    print(json.dumps(payload, ensure_ascii=False, indent=2))
    print(f"PASS: validation written to {out_path}")


if __name__ == "__main__":
    main()
```

</details>
