### PR TITLE
Restore EAMET editor integration

### DIFF
--- a/easyeditor/editors/editor.py
+++ b/easyeditor/editors/editor.py
@@ -135,10 +135,10 @@ class BaseEditor:
             else:
                 raise NotImplementedError
 
-            if self.tok is not None and (isinstance(self.tok, GPT2Tokenizer) or isinstance(self.tok, GPT2TokenizerFast) or isinstance(self.tok, LlamaTokenizer) or isinstance(self.tok, LlamaTokenizerFast) or isinstance(self.tok, PreTrainedTokenizerFast)) and (hparams.alg_name not in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit','CORE', 'SPHERE']):
+            if self.tok is not None and (isinstance(self.tok, GPT2Tokenizer) or isinstance(self.tok, GPT2TokenizerFast) or isinstance(self.tok, LlamaTokenizer) or isinstance(self.tok, LlamaTokenizerFast) or isinstance(self.tok, PreTrainedTokenizerFast)) and (hparams.alg_name not in ['ROME', 'MEMIT', 'EMMET', 'EAMET', 'R-ROME','AlphaEdit','CORE', 'SPHERE']):
                 LOG.info('AutoRegressive Model detected, set the padding side of Tokenizer to left...')
                 self.tok.padding_side = 'left'
-            if self.tok is not None and ('mistral' in self.model_name.lower() or 'llama' in self.model_name.lower() or 'qwen' in self.model_name.lower()) and (hparams.alg_name in ['ROME', 'MEMIT', 'EMMET', 'R-ROME','AlphaEdit', 'CORE', 'SPHERE']):
+            if self.tok is not None and ('mistral' in self.model_name.lower() or 'llama' in self.model_name.lower() or 'qwen' in self.model_name.lower()) and (hparams.alg_name in ['ROME', 'MEMIT', 'EMMET', 'EAMET', 'R-ROME','AlphaEdit', 'CORE', 'SPHERE']):
                 LOG.info('AutoRegressive Model detected, set the padding side of Tokenizer to right...')
                 self.tok.padding_side = 'right'
         else:

--- a/easyeditor/models/eamet/compute_z.py
+++ b/easyeditor/models/eamet/compute_z.py
@@ -15,6 +15,20 @@ import torch.nn.functional as F
 
 # initial_sim_z = None
 
+def get_target_new_str(request: Dict) -> str:
+    target_new = request["target_new"]
+    if isinstance(target_new, dict):
+        return target_new["str"]
+    return target_new
+
+
+def set_target_new_str(request: Dict, value: str) -> None:
+    if isinstance(request["target_new"], dict):
+        request["target_new"]["str"] = value
+    else:
+        request["target_new"] = value
+
+
 def compute_z(
     model: AutoModelForCausalLM,
     tok: AutoTokenizer,
@@ -71,7 +85,7 @@ def compute_z(
     device = normalize_device(getattr(hparams, "device", None))
     rewrite_module_name = hparams.layer_module_tmp.format(layer)
     rewrite_device = get_module_device(nethook.get_module(model, rewrite_module_name), device)
-    target_ids = tok(request["target_new"]["str"], return_tensors="pt").to(device)["input_ids"][0]
+    target_ids = tok(get_target_new_str(request), return_tensors="pt").to(device)["input_ids"][0]
 
     print(f"DEBUG INFO:target_ids:{target_ids}")
     print(f"DEBUG INFO:tok('English'):{tok('English')}")
@@ -90,7 +104,7 @@ def compute_z(
         opt_target_ids = target_ids
     
     print(f"opt_target_ids:{opt_target_ids}")
-    tgt_str = request["target_new"]["str"]
+    tgt_str = get_target_new_str(request)
     ### tokenizer.decode([]) gives nothing
     
     if "llama-3.1" in str(model.config._name_or_path).lower():
@@ -383,7 +397,8 @@ def get_module_input_output_at_words(
     module_template: str,
     fact_token_strategy: str,
     minus = None,
-    change_padding = False
+    change_padding = False,
+    track = None,
 ) -> Tuple[torch.Tensor]:
     """
     Retrieves detached representations for a word at the input and
@@ -395,7 +410,6 @@ def get_module_input_output_at_words(
         tok=tok,
         layer=layer,
         module_template=module_template,
-        change_padding=change_padding
     )
     if "subject_" in fact_token_strategy and fact_token_strategy.index("subject_") == 0:
         context_info = dict(
@@ -403,8 +417,12 @@ def get_module_input_output_at_words(
             words=words,
         )
         subtoken = fact_token_strategy[len("subject_") :]
+        if track in {"in", "out"}:
+            return repr_tools.get_reprs_at_word_tokens(
+                track=track, subtoken=subtoken, **context_info, **word_repr_args
+            ).detach()
         l_input, l_output = repr_tools.get_reprs_at_word_tokens(
-            track="both", subtoken=subtoken, minus=minus, **context_info, **word_repr_args
+            track="both", subtoken=subtoken, **context_info, **word_repr_args
         )
     elif fact_token_strategy == "last":
         raise Exception("This is definitely bugged, fix it.")
@@ -447,7 +465,6 @@ def find_fact_lookup_idx(
             context_templates=[prompt],
             words=[subject],
             subtoken=fact_token_strategy[len("subject_") :],
-            model_name=model_name
         )[0][0]
     else:
         raise ValueError(f"fact_token={fact_token_strategy} not recognized")

--- a/easyeditor/models/eamet/eamet_main.py
+++ b/easyeditor/models/eamet/eamet_main.py
@@ -20,7 +20,13 @@ from ...util.generate import generate_fast, generate_standard
 from ...util.globals import *
 
 from .compute_ks import compute_ks
-from .compute_z import compute_z, get_module_input_output_at_words, find_fact_lookup_idx
+from .compute_z import (
+    compute_z,
+    find_fact_lookup_idx,
+    get_module_input_output_at_words,
+    get_target_new_str,
+    set_target_new_str,
+)
 from .hparams import EAMETHyperParams
 
 import torch.nn.functional as F
@@ -40,7 +46,9 @@ def apply_eamet_to_model(
     cache_id: int = 0,
     motivation_exp: bool=False,
     cache_motivation_fname: Optional[str] = None,
-    duplicate_subjects: Optional[Dict[str, List[int]]] = None
+    duplicate_subjects: Optional[Dict[str, List[int]]] = None,
+    keep_original_weight=False,
+    **kwargs
 ) -> Tuple[AutoModelForCausalLM, Dict[str, Any]]:
     """
     Returns a model with the desired changes.
@@ -105,8 +113,15 @@ def execute_eamet(
     requests = deepcopy(requests)
 
     for i, request in enumerate(requests):
-        if request["target_new"]["str"][0] != " ":
-            requests[i]["target_new"]["str"] = " " + request["target_new"]["str"]
+        target_new = get_target_new_str(request)
+        if target_new[0] != " ":
+            set_target_new_str(requests[i], " " + target_new)
+
+        if '{}' not in request['prompt']:
+            assert request['subject'] in request['prompt'] or \
+                   print(f"Subject:{request['subject']} do not exist in prompt: {request['prompt']}")
+
+            requests[i]['prompt'] = requests[i]['prompt'].replace(requests[i]['subject'], '{}')
 
     weights = {
         f"{hparams.rewrite_module_tmp.format(layer)}.weight": nethook.get_parameter(
@@ -345,11 +360,12 @@ def get_cov(
             model,
             tok,
             layer_name,
-            STATS_DIR,
+            hparams.stats_dir,
             mom2_dataset,
             to_collect=["mom2"],
             sample_size=mom2_n_samples,
             precision=mom2_dtype,
+            hparams=hparams,
             force_recompute=force_recompute,
         )
         COV_CACHE[key] = stat.mom2.moment().float().to("cpu")

--- a/easyeditor/models/eamet/hparams.py
+++ b/easyeditor/models/eamet/hparams.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import List, Literal
+from typing import List, Literal, Union
 
-from ...util.hparams import HyperParams
+from ...util.hparams import HyperParams, load_hparams_config, normalize_alg_name
 
 
 @dataclass
@@ -29,7 +29,7 @@ class EAMETHyperParams(HyperParams):
     weight_decay_method: Literal["norm", "fix_ks"]
 
     mom2_adjustment: bool
-    mom2_update_weight: float
+    mom2_update_weight: List[float]
 
     # Module templates
     rewrite_module_tmp: str
@@ -43,3 +43,22 @@ class EAMETHyperParams(HyperParams):
     mom2_dataset: str
     mom2_n_samples: int
     mom2_dtype: str
+    alg_name: str
+    device: Union[int, str]
+    model_name: str
+    stats_dir: str
+
+    max_length: int = 40
+    batch_size: int = 1
+    model_parallel: bool = False
+
+    @classmethod
+    def from_hparams(cls, hparams_name_or_path: str):
+        config = load_hparams_config(hparams_name_or_path)
+        config = normalize_alg_name(config, "EAMET")
+        if not isinstance(config["mom2_update_weight"], list):
+            config["mom2_update_weight"] = [
+                config["mom2_update_weight"]
+                for _ in config["layers"]
+            ]
+        return cls(**config)

--- a/easyeditor/util/alg_dict.py
+++ b/easyeditor/util/alg_dict.py
@@ -17,6 +17,7 @@ from ..models.melo import MELOHyperParams, apply_melo_to_model
 from ..models.wise import WISEHyperParams, apply_wise_to_model, apply_wise_to_multimodal_model
 from ..models.r_rome import R_ROMEHyperParams, apply_r_rome_to_model
 from ..models.emmet import EMMETHyperParams, apply_emmet_to_model
+from ..models.eamet import EAMETHyperParams, apply_eamet_to_model
 from ..models.alphaedit import AlphaEditHyperParams, apply_AlphaEdit_to_model
 from ..models.SPHERE import SPHEREHyperParams, apply_SPHERE_to_model
 from ..models.core import COREHyperParams, apply_core_to_model
@@ -46,6 +47,7 @@ ALG_DICT = {
     'WISE': apply_wise_to_model,
     'R-ROME': apply_r_rome_to_model,
     "EMMET": apply_emmet_to_model,
+    "EAMET": apply_eamet_to_model,
     "AlphaEdit": apply_AlphaEdit_to_model,
     "SPHERE": apply_SPHERE_to_model,
     "ULTRAEDIT": UltraEditRewriteExecutor().apply_to_model,

--- a/hparams/EAMET/qwen2.5-7b.yaml
+++ b/hparams/EAMET/qwen2.5-7b.yaml
@@ -1,0 +1,33 @@
+alg_name: "EAMET"
+model_name: "./hugging_cache/Qwen2.5-7B"
+stats_dir: "./data/stats"
+device: 0
+layers: [4, 5, 6, 7, 8]
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+ks_bs: 1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+clamp_norm_factor: 4
+clamp_ks_factor: 1
+kl_factor: 0.0625
+cs_factor: 1
+mse_factor: 1
+tau: 0.07
+norm_factor: 1e-3
+delta_init: "target_init"
+weight_decay_method: "norm"
+mom2_adjustment: true
+mom2_update_weight: [15000, 15000, 15000, 15000, 15000]
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "model.embed_tokens"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false


### PR DESCRIPTION
## Summary

- add an EAMET hparams config and register EAMET in the edit-side algorithm map so it can be used through `BaseEditor`
- load EAMET hparams through the shared YAML loader, including `alg_name` normalization and list handling for `mom2_update_weight`
- support current string `target_new` requests while keeping compatibility with legacy dict `target_new` requests
- update EAMET calls for current shared `repr_tools` and `stats_dir` interfaces
- include EAMET in the ROME/MEMIT-style right-padding tokenizer branch

## Validation

- `git diff --check`
- `py_compile` for the changed EAMET, editor, and registry source files
- hparams loading and `ALG_DICT[EAMET]` registration checks
- Qwen2.5-1.5B one-request direct apply smoke and `BaseEditor.edit` smoke
- forced two-GPU compatibility matrix covering layer 0 and final-layer edits on both visible GPUs, plus current string and legacy dict `target_new` formats
- result: 7/7 compatibility cases passed

This validation checks runtime/integration/device-placement compatibility. It does not claim changes to editing quality metrics.