### PR TITLE
Register DEFER BaseEditor integration

### DIFF
--- a/easyeditor/editors/utils.py
+++ b/easyeditor/editors/utils.py
@@ -10,7 +10,7 @@ from ..util import nethook
 from ..util.device import copy_to_param
 
 
-CALLABLE_RESTORE_ALGS = {"KN", "GRACE", "WISE"}
+CALLABLE_RESTORE_ALGS = {"KN", "GRACE", "WISE", "DEFER"}
 PEFT_RESTORE_ALGS = {"LoRA", "QLoRA", "DPO"}
 KEEP_EDITED_MODEL_ALGS = {"MELO"}
 

--- a/easyeditor/util/alg_dict.py
+++ b/easyeditor/util/alg_dict.py
@@ -24,6 +24,7 @@ from .. models.deepedit_api import DeepEditApiHyperParams, apply_deepedit_api_to
 from ..models.dpo import DPOHyperParams, apply_dpo_to_model
 from ..models.ultraedit import UltraEditHyperParams, UltraEditRewriteExecutor
 from ..models.simie import SimIEHyperParams, apply_simie_to_model
+from ..models.defer import DeferHyperParams, apply_defer_to_model
 
 
 ALG_DICT = {
@@ -51,7 +52,8 @@ ALG_DICT = {
     "ULTRAEDIT": UltraEditRewriteExecutor().apply_to_model,
     "CORE": apply_core_to_model,
     "DeepEdit-Api": apply_deepedit_api_to_model,
-    "SimIE": apply_simie_to_model
+    "SimIE": apply_simie_to_model,
+    "DEFER": apply_defer_to_model
 }
 
 MULTIMODAL_EDIT_ALGS = {


### PR DESCRIPTION
## Summary

- register `DEFER` in `ALG_DICT` so `hparams/DEFER/*.yaml` configs can be used through the standard `BaseEditor` path
- import the DEFER hparams/apply function alongside the other editing algorithms
- include `DEFER` in the callable restore group because `apply_defer_to_model` returns `editor.reset_layer` rather than a dict of copied weights
- keep existing hparams files and public editor call patterns unchanged

## Validation

- `git diff --check`
- `python -m py_compile easyeditor/util/alg_dict.py easyeditor/editors/utils.py easyeditor/models/defer/defer_main.py easyeditor/models/defer/defer_hparams.py easyeditor/models/defer/DEFER.py`
- static lookup check confirmed `DeferHyperParams.from_hparams("hparams/DEFER/llama-7b.yaml")` resolves `ALG_DICT[hparams.alg_name]` and `DEFER` is in the callable restore group
- real 20-row ZsRE `BaseEditor.edit` integration run with Qwen2.5-1.5B and `n_iter=100`, including rewrite, rephrase, locality evaluation, and non-sequential restore, completed successfully
- restore check confirmed the returned `weights_copy` is callable and the editor model returns to `Qwen2ForCausalLM` without DEFER adaptor parameters after restore