### PR TITLE
Add Qwen3.5-9B hparams

### DIFF
--- a/easyeditor/models/alphaedit/AlphaEdit_main.py
+++ b/easyeditor/models/alphaedit/AlphaEdit_main.py
@@ -61,7 +61,11 @@ def apply_AlphaEdit_to_model(
         print(os.path.abspath(hparams.P_loc))
         print(f"The null-space projection matrix P does not exist and now calculate.")
         W_out = nethook.get_parameter(model, f"{hparams.rewrite_module_tmp.format(hparams.layers[-1])}.weight")
-        if "llama" in hparams.model_name.lower() or "gpt-j-6b" in hparams.model_name.lower():
+        if (
+            "llama" in hparams.model_name.lower()
+            or "qwen" in hparams.model_name.lower()
+            or "gpt-j-6b" in hparams.model_name.lower()
+        ):
             P = torch.zeros((len(hparams.layers), W_out.shape[1], W_out.shape[1]), device="cpu")
         elif "gpt2-xl" in hparams.model_name.lower():
             P = torch.zeros((len(hparams.layers), W_out.shape[0], W_out.shape[0]), device="cpu")

--- a/easyeditor/models/grace/GRACE.py
+++ b/easyeditor/models/grace/GRACE.py
@@ -243,7 +243,7 @@ class GRACEAdapter(torch.nn.Module):
             return layer_out
         smallest_dist, self.chosen_key = dists.min(0)
         smallest_dist = smallest_dist.view(-1, 1)
-        chosen_value = self.values[self.chosen_key]
+        chosen_value = self.values[self.chosen_key].to(dtype=layer_out.dtype)
         eps = self.epsilons[self.chosen_key].view(-1, 1)
 
         if (self.config.val_train == "adv") and (self.training):

--- a/hparams/AlphaEdit/qwen3.5-9b.yaml
+++ b/hparams/AlphaEdit/qwen3.5-9b.yaml
@@ -1,0 +1,27 @@
+alg_name: "AlphaEdit"
+model_name: "./hugging_cache/Qwen3.5-9B"
+stats_dir: "./data/stats"
+P_loc: "./null_space_project.pt"
+device: 0
+layers: [4, 5, 6, 7, 8]
+clamp_norm_factor: 4
+layer_selection: "all"
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+kl_factor: 0.0625
+mom2_adjustment: true
+mom2_update_weight: 15000
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.linear_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+nullspace_threshold: 2e-2
+L2: 1

--- a/hparams/FT/qwen3.5-9b.yaml
+++ b/hparams/FT/qwen3.5-9b.yaml
@@ -1,0 +1,27 @@
+# We provide two implementations (objective_optimization):
+#   1. prompt_last: the method of ROME's (https://arxiv.org/abs/2202.05262) original paper, which calculates nll loss through the last token of the input.
+#   2. target_new: the standard autoregressive method, using the cross-entropy loss function
+
+alg_name: "FT"
+model_name: "./hugging_cache/Qwen3.5-9B"
+device: 0
+
+layers: [27]
+num_steps: 25
+batch_size: 1
+max_length: 40
+lr: 5e-4
+weight_decay: 0
+kl_factor: 0
+norm_constraint: false
+# In our survey paper(https://arxiv.org/abs/2401.01286)
+# "prompt_last" corresponds to the results of FT-L.
+# "target_new" corresponds to the results of FT-M.
+objective_optimization: "prompt_last"
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj.weight"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+model_parallel: false

--- a/hparams/GRACE/qwen3.5-9b.yaml
+++ b/hparams/GRACE/qwen3.5-9b.yaml
@@ -1,0 +1,19 @@
+alg_name: "GRACE"
+model_name: "./hugging_cache/Qwen3.5-9B"
+device: 0
+
+inner_params:
+- model.layers[18].mlp.down_proj.weight
+
+edit_lr: 1.0
+n_iter: 50
+eps: 5.0
+dist_fn: euc # euc, mmd, cos
+val_init: cold # cold, warm
+val_train: sgd # sgd, pert
+val_reg: None # early
+reg: early_stop # early_stop
+replacement: replace_last # replace_last, replace_all, replace_prompt
+eps_expand: coverage # , moving_avg, decay
+num_pert: 8 # only matters when using perturbation training
+dropout: 0.0

--- a/hparams/R-ROME/qwen3.5-9b.yaml
+++ b/hparams/R-ROME/qwen3.5-9b.yaml
@@ -1,0 +1,29 @@
+alg_name: "R-ROME"
+model_name: "./hugging_cache/Qwen3.5-9B"
+stats_dir: "./data/stats"
+device: 0
+
+layers: [5]
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+clamp_norm_factor: 4
+kl_factor: 0.0625
+mom2_adjustment: false
+context_template_length_params: [[5, 10], [10, 10]]
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false
+fp16: false
+enable_prompt_keys: false
+enable_random_prefix_keys: true
+original_implementation: false

--- a/hparams/ROME/qwen3.5-9b.yaml
+++ b/hparams/ROME/qwen3.5-9b.yaml
@@ -1,0 +1,26 @@
+alg_name: "ROME"
+model_name: "./hugging_cache/Qwen3.5-9B"
+stats_dir: "./data/stats"
+device: 0
+
+layers: [5]
+fact_token: "subject_last"
+v_num_grad_steps: 25
+v_lr: 5e-1
+v_loss_layer: 27
+v_weight_decay: 1e-3
+clamp_norm_factor: 4
+kl_factor: 0.0625
+mom2_adjustment: false
+context_template_length_params: [[5, 10], [10, 10]]
+rewrite_module_tmp: "model.layers.{}.mlp.down_proj"
+layer_module_tmp: "model.layers.{}"
+mlp_module_tmp: "model.layers.{}.mlp"
+attn_module_tmp: "model.layers.{}.self_attn"
+ln_f_module: "model.norm"
+lm_head_module: "lm_head"
+mom2_dataset: "wikipedia"
+mom2_n_samples: 100000
+mom2_dtype: "float32"
+model_parallel: false
+fp16: false

--- a/hparams/WISE/qwen3.5-9b.yaml
+++ b/hparams/WISE/qwen3.5-9b.yaml
@@ -1,0 +1,30 @@
+alg_name: "WISE"
+model_name: "./hugging_cache/Qwen3.5-9B"
+device: 0
+
+mask_ratio: 0.2
+edit_lr: 1.0
+n_iter: 70
+norm_constraint: 1.0
+act_margin: [5.0, 20.0, 10.0] # alpha, beta, gamma
+act_ratio: 0.88
+save_freq: 500
+merge_freq: 1000
+merge_alg: 'ties'
+objective_optimization: 'only_label'
+inner_params:
+- model.layers[23].mlp.down_proj.weight
+
+
+## alternative: WISE-Merge, WISE-Retrieve
+
+# for merge (if merge)
+densities: 0.53
+weights: 1.0
+
+# for retrieve (if retrieve, pls set to True)
+retrieve: True
+replay: False # True --> will replay the past editing instances: see https://arxiv.org/abs/2405.14768 Appendix B.3
+
+model_parallel: False
+use_chat_template: True


### PR DESCRIPTION
Adds Qwen3.5-9B hparams for FT, ROME, GRACE, R-ROME, WISE, and AlphaEdit.\n\nAlso updates Qwen3.5 execution compatibility for AlphaEdit and GRACE.\n\nChecks:\n- hparams load for all six methods\n- serial ZsRE checks for FT, WISE, ROME, and R-ROME\n- python -m py_compile easyeditor/models/grace/GRACE.py easyeditor/models/alphaedit/AlphaEdit_main.py\n- git diff --check